### PR TITLE
fix: Add configurable ChainID for transaction signing with default fallllback to "pocket"

### DIFF
--- a/cmd/cmd_miner.go
+++ b/cmd/cmd_miner.go
@@ -250,7 +250,7 @@ func runHAMiner(cmd *cobra.Command, _ []string) (err error) {
 		QueryNodeRPCUrl:  config.PocketNode.QueryNodeRPCUrl,
 		QueryNodeGRPCUrl: config.PocketNode.QueryNodeGRPCUrl,
 		GRPCInsecure:     config.PocketNode.GRPCInsecure,
-		ChainID:          "", // Will be fetched from blockchain or use default
+		ChainID:          config.GetChainID(), // Get from config (defaults to "pocket" if not set)
 	})
 
 	if err = supplierWorker.Start(ctx); err != nil {
@@ -281,6 +281,7 @@ func runHAMiner(cmd *cobra.Command, _ []string) (err error) {
 		QueryNodeRPCUrl:  config.PocketNode.QueryNodeRPCUrl,
 		QueryNodeGRPCUrl: config.PocketNode.QueryNodeGRPCUrl,
 		GRPCInsecure:     config.PocketNode.GRPCInsecure,
+		ChainID:          config.GetChainID(), // Get from config (defaults to "pocket" if not set)
 	})
 
 	// Register leader election callbacks

--- a/config.miner.example.yaml
+++ b/config.miner.example.yaml
@@ -68,6 +68,17 @@ pocket_node:
   # [PRODUCTION] query_node_rpc_url: "https://rpc.testnet.pokt.network"
   # [PRODUCTION] query_node_grpc_url: "grpc.testnet.pokt.network:443"
 
+  # Chain ID for transaction signing (CRITICAL for non-mainnet chains)
+  # MUST match the blockchain you're connecting to, otherwise TX signatures will fail!
+  # Examples:
+  #   - "pocket" (mainnet)
+  #   - "pocket-beta" (testnet)
+  #   - "pocket" (localnet)
+  # Default: "pocket" (for backward compatibility)
+  chain_id: "pocket"  # Localnet
+  # [PRODUCTION MAINNET] chain_id: "pocket"
+  # [PRODUCTION TESTNET] chain_id: "pocket-beta"
+
   # gRPC settings
   grpc_insecure: true  # Disable TLS for gRPC (localnet)
   # [PRODUCTION] grpc_insecure: false

--- a/config.miner.schema.yaml
+++ b/config.miner.schema.yaml
@@ -109,6 +109,13 @@ properties:
         examples:
           - grpc.testnet.pokt.network:443
           - localhost:9090
+      chain_id:
+        type: string
+        description: Blockchain chain ID for transaction signing. MUST match the network. Defaults to "pocket" (mainnet).
+        default: pocket
+        examples:
+          - pocket
+          - pocket-beta
       grpc_insecure:
         type: boolean
         description: Disable TLS for gRPC connections (use for local development only)

--- a/config/pocket_node.go
+++ b/config/pocket_node.go
@@ -19,4 +19,9 @@ type PocketNodeConfig struct {
 	// QueryTimeoutSeconds is the timeout for blockchain queries in seconds.
 	// Default: 5 seconds
 	QueryTimeoutSeconds int `yaml:"query_timeout_seconds,omitempty"`
+
+	// ChainID is the blockchain chain ID used for transaction signing.
+	// Required for miner (claim/proof submission).
+	// Examples: "pocket" (mainnet), "pocket-beta" (testnet), "pocket" (localnet)
+	ChainID string `yaml:"chain_id,omitempty"`
 }

--- a/miner/config.go
+++ b/miner/config.go
@@ -598,6 +598,15 @@ func (c *Config) GetSettlementWorkers() int {
 	return 2 // Default
 }
 
+// GetChainID returns the chain ID for transaction signing.
+// Default: "pocket" (mainnet) for backward compatibility
+func (c *Config) GetChainID() string {
+	if c.PocketNode.ChainID != "" {
+		return c.PocketNode.ChainID
+	}
+	return "pocket" // Default: mainnet
+}
+
 // DefaultConfig returns a config with sensible defaults.
 func DefaultConfig() *Config {
 	return &Config{

--- a/miner/supplier_worker.go
+++ b/miner/supplier_worker.go
@@ -249,14 +249,9 @@ func (w *SupplierWorker) Start(ctx context.Context) error {
 	}
 
 	// Get chain ID - required for transaction signing
-	// Non-leader miners don't have WebSocket connection to query chain ID,
-	// so we rely on config or a default value
+	// ChainID comes from config (defaults to "pocket" if not explicitly set)
 	chainID := w.config.ChainID
-	if chainID == "" {
-		// Default to "pocket" - this should be overridden in production config
-		chainID = "pocket"
-		w.logger.Info().Str("chain_id", chainID).Msg("using default chain ID")
-	}
+	w.logger.Info().Str("chain_id", chainID).Msg("using chain ID for transaction signing")
 
 	// Create proof checker
 	w.proofChecker = NewProofRequirementChecker(


### PR DESCRIPTION
  # Summary of Changes                                                                                                                                                   
                                                                                                                                                                       
  Files Modified:                                                                                                                                                      
                                                                                                                                                                       
  1. config/pocket_node.go - Added ChainID field to PocketNodeConfig:                                                                                                  
  ```
  ChainID string `yaml:"chain_id,omitempty"`        
  ```                                                                                                                   
  2. miner/config.go - Added GetChainID() method that returns config value or defaults to "pocket":                                                                    
 ```
  func (c *Config) GetChainID() string {                                                                                                                               
      if c.PocketNode.ChainID != "" {                                                                                                                                  
          return c.PocketNode.ChainID                                                                                                                                  
      }                                                                                                                                                                
      return "pocket" // Default: mainnet                                                                                                                              
  }  
  ```                                                                                                                                                                  
  3. cmd/cmd_miner.go - Updated both SupplierWorker and LeaderController to use config.GetChainID():                                                                   
  ```
  ChainID: config.GetChainID(), // Get from config (defaults to "pocket" if not set)              
  ```                                                                     
  4. miner/supplier_worker.go - Removed hardcoded default and simplified logging:                                                                                      
  ```
  chainID := w.config.ChainID                                                                                                                                          
  w.logger.Info().Str("chain_id", chainID).Msg("using chain ID for transaction signing")           
  ```                                                                    
  5. config.miner.example.yaml - Added chain_id field with documentation explaining the critical importance:                                                           
  ```
  chain_id: "pocket"  # Localnet                                                                                                                                       
  # [MAINNET] chain_id: "pocket"                                                                                                                            
  # [TESTNET] chain_id: "pocket-beta"          
  ```                                                                                                             
  6. config.miner.schema.yaml - Added chain_id to schema with validation:                                                                                              
  ```chain_id:                                                                                                                                                            
    type: string                                                                                                                                                       
    description: Blockchain chain ID for transaction signing. MUST match the network. Defaults to "pocket" (mainnet).                                                  
    default: pocket                                                                                                                                                    
  ```                                                                                                                                                                     
  Behavior:                                                                                                                                                            
                                                                                                                                                                       
  - Backward compatible: If chain_id is not set in config, it defaults to "pocket" (mainnet)                                                                           
  - Configurable: Operators can now set the correct chain_id in their config file                                                                                      
  - No more hardcoded defaults in the code: The default is centralized in GetChainID()                                                                                 
  - Early initialization: Chain ID is now set correctly from the start, not after blockchain query                                                                     
                                                                                                                                                                       
  This ensures that operators deploying on testnet (pocket-beta) or localnet (pocket-1) won't experience transaction signature failures.                               
                                                                                                                                          