### PR TITLE
feat(miner): make settlement monitor optional via config

### DIFF
--- a/config.miner.example.yaml
+++ b/config.miner.example.yaml
@@ -189,6 +189,14 @@ balance_monitor:
   stake_critical_proof_threshold: 3    # Critical when < 3 missed proofs remaining
 
 # ==============================================================================
+# Settlement Monitor (On-Chain Claim Settlement Tracking)
+# ==============================================================================
+# Tracks on-chain claim/proof settlement events via block_results.
+# Disabled by default — enable for operators who want on-chain settlement visibility.
+# settlement_monitor:
+#   enabled: false  # Set to true to enable on-chain settlement event tracking
+
+# ==============================================================================
 # Session Lifecycle Configuration
 # ==============================================================================
 # NOTE: Session lifecycle is event-driven (uses block events instead of polling)

--- a/config.miner.schema.yaml
+++ b/config.miner.schema.yaml
@@ -274,6 +274,15 @@ properties:
       type: number
       minimum: 0
 
+  settlement_monitor:
+    type: object
+    description: On-chain claim settlement tracking configuration
+    properties:
+      enabled:
+        type: boolean
+        description: Enable on-chain settlement event tracking
+        default: false
+
   balance_monitor:
     type: object
     description: Balance and stake monitoring configuration (Feature 4)

--- a/miner/config_test.go
+++ b/miner/config_test.go
@@ -212,19 +212,27 @@ func TestGetMasterPoolSize(t *testing.T) {
 	cfg := &Config{}
 
 	// Test auto-calculation with small supplier count (CPU-bound)
-	// With default values: cpu_multiplier=4, workers_per_supplier=6, query=20, settlement=2
-	// On a machine with N CPUs: max(N×4, suppliers×6) + 22
-	// For 5 suppliers: max(N×4, 30) + 22
+	// With default values: cpu_multiplier=4, workers_per_supplier=6, query=20
+	// Settlement monitor disabled by default, so overhead = query_workers only (20)
+	// On a machine with N CPUs: max(N×4, suppliers×6) + 20
+	// For 5 suppliers: max(N×4, 30) + 20
 	// This test uses 5 suppliers which should be CPU-bound on most machines
 	size := cfg.GetMasterPoolSize(5)
-	require.Greater(t, size, 22) // At minimum, overhead is 22
+	require.Greater(t, size, 20) // At minimum, overhead is 20 (no settlement workers)
 
 	// Test auto-calculation with high supplier count (supplier-bound)
-	// For 78 suppliers: max(N×4, 468) + 22 = 468 + 22 = 490 (on most machines)
+	// For 78 suppliers: max(N×4, 468) + 20 = 468 + 20 = 488 (on most machines)
 	size = cfg.GetMasterPoolSize(78)
-	// 78 × 6 = 468, plus overhead 22 = 490
+	// 78 × 6 = 468, plus overhead 20 = 488
 	// This should be supplier-bound unless running on 117+ core machine
+	require.GreaterOrEqual(t, size, 488)
+
+	// Test with settlement monitor enabled (adds settlement_workers to overhead)
+	cfg.SettlementMonitor.Enabled = true
+	size = cfg.GetMasterPoolSize(78)
+	// 78 × 6 = 468, plus overhead 22 (20 query + 2 settlement) = 490
 	require.GreaterOrEqual(t, size, 490)
+	cfg.SettlementMonitor.Enabled = false // reset
 
 	// Test explicit override
 	cfg.WorkerPools.MasterPoolSize = 500

--- a/tilt/docker/config/miner-config.yaml
+++ b/tilt/docker/config/miner-config.yaml
@@ -22,6 +22,9 @@ block_health_monitor:
   enabled: true
   slowness_threshold: 1.5
 
+settlement_monitor:
+  enabled: false  # Off by default — enable for on-chain settlement tracking
+
 balance_monitor:
   enabled: true
   check_interval_seconds: 300


### PR DESCRIPTION
## Summary
- Add `settlement_monitor.enabled` config flag (default: `false`) so operators can opt-in to on-chain settlement tracking
- Exclude settlement workers from master pool overhead when the monitor is disabled
- Follows the same pattern as `balance_monitor` and `block_health_monitor`

## Test plan
- [x] `make fmt lint test` passes