### PR TITLE
feat(miner): wire GetParamsAtHeight into session-bounded param reads

### DIFF
--- a/miner/claim_pipeline.go
+++ b/miner/claim_pipeline.go
@@ -339,14 +339,6 @@ func (p *ClaimPipeline) submitClaimBatch(ctx context.Context, claims []*ClaimReq
 		return
 	}
 
-	// Get shared params for timeout calculation
-	sharedParams, err := p.sharedClient.GetParams(ctx)
-	if err != nil {
-		p.logger.Error().Err(err).Msg("failed to get shared params for claim submission")
-		p.notifyClaimResults(claims, false, err)
-		return
-	}
-
 	// Group claims by session end height for proper timeout calculation
 	claimsByEndHeight := make(map[int64][]*ClaimRequest)
 	for _, claim := range claims {
@@ -354,6 +346,16 @@ func (p *ClaimPipeline) submitClaimBatch(ctx context.Context, claims []*ClaimReq
 	}
 
 	for sessionEndHeight, heightClaims := range claimsByEndHeight {
+		// Fetch the shared params that were effective at this session's height,
+		// per session end height. A single batch can span a session-length change
+		// (poktroll #543), so live params would compute the wrong window for an
+		// old-epoch group.
+		sharedParams, err := p.sharedClient.GetParamsAtHeight(ctx, sessionEndHeight)
+		if err != nil {
+			p.logger.Error().Err(err).Int64("session_end_height", sessionEndHeight).Msg("failed to get shared params for claim submission")
+			p.notifyClaimResults(heightClaims, false, err)
+			continue
+		}
 		p.submitClaimsForHeight(ctx, heightClaims, sessionEndHeight, sharedParams)
 	}
 }
@@ -461,7 +463,8 @@ func (p *ClaimPipeline) WaitForClaimWindow(
 	ctx context.Context,
 	sessionEndHeight int64,
 ) (claimWindowOpenHeight int64, blockHash []byte, err error) {
-	sharedParams, err := p.sharedClient.GetParams(ctx)
+	// Params effective at the session's height (poktroll #543 anchored grid).
+	sharedParams, err := p.sharedClient.GetParamsAtHeight(ctx, sessionEndHeight)
 	if err != nil {
 		return 0, nil, fmt.Errorf("failed to get shared params: %w", err)
 	}

--- a/miner/claim_pipeline_test.go
+++ b/miner/claim_pipeline_test.go
@@ -129,6 +129,11 @@ func (m *mockTxClient) getProofCalls() int {
 // mockSharedQueryClient implements client.SharedQueryClient for testing
 type mockSharedQueryClient struct {
 	params *sharedtypes.Params
+
+	// paramsAtHeightFn, when set, overrides GetParamsAtHeight so tests can return
+	// height-specific params (simulating params that were effective at an older
+	// session height). When nil, GetParamsAtHeight delegates to GetParams.
+	paramsAtHeightFn func(ctx context.Context, queryHeight int64) (*sharedtypes.Params, error)
 }
 
 func (m *mockSharedQueryClient) GetParams(ctx context.Context) (*sharedtypes.Params, error) {
@@ -147,6 +152,9 @@ func (m *mockSharedQueryClient) GetParams(ctx context.Context) (*sharedtypes.Par
 }
 
 func (m *mockSharedQueryClient) GetParamsAtHeight(ctx context.Context, queryHeight int64) (*sharedtypes.Params, error) {
+	if m.paramsAtHeightFn != nil {
+		return m.paramsAtHeightFn(ctx, queryHeight)
+	}
 	return m.GetParams(ctx)
 }
 

--- a/miner/inclusion_tracker.go
+++ b/miner/inclusion_tracker.go
@@ -277,7 +277,8 @@ func (t *InclusionTracker) tickOnce(
 // computeClaimWindowCloseHeight returns the block height at which the claim
 // window closes for the given session.
 func (t *InclusionTracker) computeClaimWindowCloseHeight(ctx context.Context, sessionEndHeight int64) (int64, error) {
-	params, err := t.sharedClient.GetParams(ctx)
+	// Params effective at the session's height (poktroll #543 anchored grid).
+	params, err := t.sharedClient.GetParamsAtHeight(ctx, sessionEndHeight)
 	if err != nil {
 		return 0, fmt.Errorf("failed to get shared params: %w", err)
 	}

--- a/miner/lifecycle_callback.go
+++ b/miner/lifecycle_callback.go
@@ -516,12 +516,6 @@ func (lc *LifecycleCallback) OnSessionsNeedClaim(ctx context.Context, snapshots 
 
 	logger.Debug().Msg("batched sessions need claims - starting claim process")
 
-	// Get shared params
-	sharedParams, err := lc.sharedClient.GetParams(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get shared params: %w", err)
-	}
-
 	// Group sessions by session end height (they might have different claim windows)
 	// WORKAROUND: If batching is disabled, create one group per session to avoid
 	// cross-contamination where one invalid claim causes the entire batch to fail.
@@ -561,6 +555,14 @@ func (lc *LifecycleCallback) OnSessionsNeedClaim(ctx context.Context, snapshots 
 		// Get the actual session end height from the first snapshot in the group
 		// (all snapshots in a group have the same end height)
 		sessionEndHeight := groupSnapshots[0].SessionEndHeight
+
+		// Shared params effective at this session's height, not live params. After a
+		// session-length change (poktroll #543 anchored grid), an old-epoch group
+		// computed with new-epoch params would resolve the wrong claim window.
+		sharedParams, err := lc.sharedClient.GetParamsAtHeight(ctx, sessionEndHeight)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get shared params at height %d: %w", sessionEndHeight, err)
+		}
 
 		// Wait for claim window to open and get the block hash for timing spread
 		claimWindowOpenHeight := sharedtypes.GetClaimWindowOpenHeight(sharedParams, sessionEndHeight)
@@ -1212,12 +1214,6 @@ func (lc *LifecycleCallback) OnSessionsNeedProof(ctx context.Context, snapshots 
 
 	logger.Debug().Msg("batched sessions need proofs - starting proof process")
 
-	// Get shared params
-	sharedParams, err := lc.sharedClient.GetParams(ctx)
-	if err != nil {
-		return fmt.Errorf("failed to get shared params: %w", err)
-	}
-
 	// Group sessions by session end height (they might have different proof windows)
 	// WORKAROUND: If batching is disabled, create one group per session to avoid
 	// cross-contamination where one invalid proof (e.g., difficulty validation failure)
@@ -1255,6 +1251,14 @@ func (lc *LifecycleCallback) OnSessionsNeedProof(ctx context.Context, snapshots 
 		// Get the actual session end height from the first snapshot in the group
 		// (all snapshots in a group have the same end height)
 		sessionEndHeight := groupSnapshots[0].SessionEndHeight
+
+		// Shared params effective at this session's height, not live params. After a
+		// session-length change (poktroll #543 anchored grid), an old-epoch group
+		// computed with new-epoch params would resolve the wrong proof window.
+		sharedParams, err := lc.sharedClient.GetParamsAtHeight(ctx, sessionEndHeight)
+		if err != nil {
+			return fmt.Errorf("failed to get shared params at height %d: %w", sessionEndHeight, err)
+		}
 
 		// Wait for proof window to open
 		proofWindowOpenHeight := sharedtypes.GetProofWindowOpenHeight(sharedParams, sessionEndHeight)

--- a/miner/lifecycle_callback.go
+++ b/miner/lifecycle_callback.go
@@ -359,14 +359,22 @@ func (lc *LifecycleCallback) getClaimReward(
 		return sdk.Coin{}, fmt.Errorf("difficulty client not available")
 	}
 
+	// Both the shared params (ComputeUnitsToTokensMultiplier, ComputeUnitCostGranularity)
+	// and the relay mining difficulty must be those effective at the session START
+	// height, to exactly match how the chain computes the claimed uPOKT in
+	// x/proof/keeper/msg_server_create_claim.go (GetParamsAtHeight(sessionStartHeight)
+	// + GetRelayMiningDifficultyAtHeight(sessionStartHeight)). Using live shared params
+	// would diverge from the chain after a session-length / CUTTM param change.
+	sessionStartHeight := claim.SessionHeader.GetSessionStartBlockHeight()
+
 	difficulty, err := difficultyClient.GetServiceRelayDifficultyAtHeight(
-		ctx, serviceID, claim.SessionHeader.GetSessionStartBlockHeight(),
+		ctx, serviceID, sessionStartHeight,
 	)
 	if err != nil {
 		return sdk.Coin{}, fmt.Errorf("failed to fetch relay mining difficulty: %w", err)
 	}
 
-	sharedParams, err := lc.sharedClient.GetParams(ctx)
+	sharedParams, err := lc.sharedClient.GetParamsAtHeight(ctx, sessionStartHeight)
 	if err != nil {
 		return sdk.Coin{}, fmt.Errorf("failed to get shared params: %w", err)
 	}

--- a/miner/proof_pipeline.go
+++ b/miner/proof_pipeline.go
@@ -329,13 +329,6 @@ func (p *ProofPipeline) submitProofBatch(ctx context.Context, proofs []*ProofReq
 		return
 	}
 
-	sharedParams, err := p.sharedClient.GetParams(ctx)
-	if err != nil {
-		p.logger.Error().Err(err).Msg("failed to get shared params for proof submission")
-		p.notifyProofResults(proofs, false, err)
-		return
-	}
-
 	// Group proofs by session end height
 	proofsByEndHeight := make(map[int64][]*ProofRequest)
 	for _, proof := range proofs {
@@ -343,6 +336,15 @@ func (p *ProofPipeline) submitProofBatch(ctx context.Context, proofs []*ProofReq
 	}
 
 	for sessionEndHeight, heightProofs := range proofsByEndHeight {
+		// Fetch the shared params effective at this session's height, per session
+		// end height. A single batch can span a session-length change (poktroll
+		// #543), so live params would compute the wrong window for an old-epoch group.
+		sharedParams, err := p.sharedClient.GetParamsAtHeight(ctx, sessionEndHeight)
+		if err != nil {
+			p.logger.Error().Err(err).Int64("session_end_height", sessionEndHeight).Msg("failed to get shared params for proof submission")
+			p.notifyProofResults(heightProofs, false, err)
+			continue
+		}
 		p.submitProofsForHeight(ctx, heightProofs, sessionEndHeight, sharedParams)
 	}
 }
@@ -430,7 +432,8 @@ func (p *ProofPipeline) WaitForProofWindow(
 	ctx context.Context,
 	sessionEndHeight int64,
 ) (proofWindowOpenHeight int64, blockHash []byte, err error) {
-	sharedParams, err := p.sharedClient.GetParams(ctx)
+	// Params effective at the session's height (poktroll #543 anchored grid).
+	sharedParams, err := p.sharedClient.GetParamsAtHeight(ctx, sessionEndHeight)
 	if err != nil {
 		return 0, nil, fmt.Errorf("failed to get shared params: %w", err)
 	}

--- a/miner/proof_requirement.go
+++ b/miner/proof_requirement.go
@@ -114,15 +114,21 @@ func (c *ProofRequirementChecker) IsProofRequired(
 	// Build the claim from the snapshot using the validated root.
 	claim := claimFromSnapshot(snapshot, rootHash)
 
-	// Get proof module parameters
+	// Get proof module parameters. The proof requirement threshold and probability
+	// are read LIVE — matching x/proof/keeper ProofRequirementForClaim, which uses
+	// k.GetParams(ctx) (live) for the proof params.
 	proofParams, err := c.proofClient.GetParams(ctx)
 	if err != nil {
 		RecordProofRequirementCheckError(snapshot.SupplierOperatorAddress, "get_proof_params")
 		return false, fmt.Errorf("failed to get proof params: %w", err)
 	}
 
-	// Get shared parameters
-	sharedParams, err := c.sharedClient.GetParams(ctx)
+	// Get shared parameters effective at the session START height. The chain computes
+	// claimed uPOKT (ComputeUnitsToTokensMultiplier, ComputeUnitCostGranularity) from
+	// the shared params at sessionStartHeight (ProofRequirementForClaim +
+	// msg_server_create_claim), paired with the difficulty at the same height. Live
+	// shared params would diverge from the chain's threshold decision after a param change.
+	sharedParams, err := c.sharedClient.GetParamsAtHeight(ctx, snapshot.SessionStartHeight)
 	if err != nil {
 		RecordProofRequirementCheckError(snapshot.SupplierOperatorAddress, "get_shared_params")
 		return false, fmt.Errorf("failed to get shared params: %w", err)

--- a/miner/session_lifecycle.go
+++ b/miner/session_lifecycle.go
@@ -119,10 +119,6 @@ type SessionLifecycleManager struct {
 	// Optional meter cleanup publisher for notifying relayers when sessions leave active state
 	meterCleanupPublisher MeterCleanupPublisher
 
-	// Current shared params (cached)
-	sharedParams   *sharedtypes.Params
-	sharedParamsMu sync.RWMutex
-
 	// Active sessions being monitored (lock-free concurrent map)
 	activeSessions *xsync.Map[string, *SessionSnapshot]
 
@@ -191,8 +187,8 @@ func (m *SessionLifecycleManager) Start(ctx context.Context) error {
 	m.ctx, m.cancelFn = context.WithCancel(ctx)
 	m.mu.Unlock()
 
-	// Load initial shared params
-	if err := m.refreshSharedParams(ctx); err != nil {
+	// Verify chain reachability at startup via a shared-params query.
+	if _, err := m.sharedClient.GetParams(ctx); err != nil {
 		return fmt.Errorf("failed to load shared params: %w", err)
 	}
 
@@ -274,27 +270,6 @@ func (m *SessionLifecycleManager) loadExistingSessions(ctx context.Context) erro
 	}
 
 	return nil
-}
-
-// refreshSharedParams refreshes the cached shared params.
-func (m *SessionLifecycleManager) refreshSharedParams(ctx context.Context) error {
-	params, err := m.sharedClient.GetParams(ctx)
-	if err != nil {
-		return err
-	}
-
-	m.sharedParamsMu.Lock()
-	m.sharedParams = params
-	m.sharedParamsMu.Unlock()
-
-	return nil
-}
-
-// getSharedParams returns the cached shared params.
-func (m *SessionLifecycleManager) getSharedParams() *sharedtypes.Params {
-	m.sharedParamsMu.RLock()
-	defer m.sharedParamsMu.RUnlock()
-	return m.sharedParams
 }
 
 // TrackSession starts tracking a new session.
@@ -397,8 +372,6 @@ func (m *SessionLifecycleManager) UpdateSessionRelayCount(ctx context.Context, s
 func (m *SessionLifecycleManager) lifecycleChecker(ctx context.Context) {
 	defer m.wg.Done()
 
-	_ = m.getSharedParams() // Ensure params are cached
-
 	// Check if block client supports Subscribe() method for fan-out
 	if subscriber, ok := m.blockClient.(interface {
 		Subscribe(ctx context.Context, bufferSize int) <-chan *localclient.SimpleBlock
@@ -442,13 +415,6 @@ func (m *SessionLifecycleManager) lifecycleCheckerEventDriven(ctx context.Contex
 			lastHeight = currentHeight
 			currentBlockHeight.Set(float64(currentHeight))
 
-			// Refresh shared params periodically (every 10 blocks)
-			if currentHeight%10 == 0 {
-				if err := m.refreshSharedParams(ctx); err != nil {
-					m.logger.Warn().Err(err).Msg("failed to refresh shared params")
-				}
-			}
-
 			// Check all sessions for transitions at this block height
 			m.checkSessionTransitions(ctx, currentHeight)
 		}
@@ -485,13 +451,6 @@ func (m *SessionLifecycleManager) lifecycleCheckerPolling(ctx context.Context) {
 			}
 			lastHeight = currentHeight
 			currentBlockHeight.Set(float64(currentHeight))
-
-			// Refresh shared params periodically (every 10 blocks)
-			if currentHeight%10 == 0 {
-				if err := m.refreshSharedParams(ctx); err != nil {
-					m.logger.Warn().Err(err).Msg("failed to refresh shared params")
-				}
-			}
 
 			// Check all sessions for transitions
 			m.checkSessionTransitions(ctx, currentHeight)

--- a/miner/session_lifecycle.go
+++ b/miner/session_lifecycle.go
@@ -515,6 +515,13 @@ func (m *SessionLifecycleManager) sessionMightNeedTransition(
 		return true // Return true to trigger cleanup in the main loop
 	}
 
+	// Fail open: if the session's epoch params could not be resolved, do NOT silently
+	// skip it — let it through to the full Redis-backed check so a transient
+	// param-query failure never drops a session that may need to claim/prove.
+	if params == nil {
+		return true
+	}
+
 	switch snapshot.State {
 	case SessionStateActive:
 		// Active sessions only need checking when claim window opens
@@ -544,10 +551,31 @@ func (m *SessionLifecycleManager) sessionMightNeedTransition(
 
 // checkSessionTransitions checks all active sessions for required state transitions.
 func (m *SessionLifecycleManager) checkSessionTransitions(ctx context.Context, currentHeight int64) {
-	params := m.getSharedParams()
-	if params == nil {
-		m.logger.Warn().Msg("shared params not available, skipping transition check")
-		return
+	// Resolve shared params at EACH session's own end height rather than from a single
+	// live snapshot. After a session-length change (poktroll #543 anchored grid), an
+	// old-epoch session's claim/proof windows must be computed with the params that were
+	// effective at that session — otherwise this transition filter would disagree with
+	// the already-height-aware submission path and fire (or time out) at the wrong height.
+	// Memoized per pass; GetParamsAtHeight's fast path returns cached live params with no
+	// RPC for current-epoch sessions, so the steady-state per-block cost is unchanged.
+	paramsByEndHeight := make(map[int64]*sharedtypes.Params)
+	resolveParams := func(sessionEndHeight int64) *sharedtypes.Params {
+		if p, ok := paramsByEndHeight[sessionEndHeight]; ok {
+			return p
+		}
+		p, err := m.sharedClient.GetParamsAtHeight(ctx, sessionEndHeight)
+		if err != nil {
+			// Cache the failure to avoid a retry storm within this pass. Callers fail
+			// open (pre-filter) / fail safe (determineTransition) on a nil result.
+			m.logger.Warn().
+				Err(err).
+				Int64("session_end_height", sessionEndHeight).
+				Msg("failed to resolve shared params at session height; session check will fail open/safe")
+			paramsByEndHeight[sessionEndHeight] = nil
+			return nil
+		}
+		paramsByEndHeight[sessionEndHeight] = p
+		return p
 	}
 
 	// OPTIMIZATION: Pre-filter sessions using in-memory state to avoid unnecessary Redis calls.
@@ -557,7 +585,7 @@ func (m *SessionLifecycleManager) checkSessionTransitions(ctx context.Context, c
 	candidateSessionIDs := make([]string, 0)
 	m.activeSessions.Range(func(sessionID string, snapshot *SessionSnapshot) bool {
 		totalSessions++
-		if m.sessionMightNeedTransition(snapshot, currentHeight, params) {
+		if m.sessionMightNeedTransition(snapshot, currentHeight, resolveParams(snapshot.SessionEndHeight)) {
 			candidateSessionIDs = append(candidateSessionIDs, sessionID)
 		}
 		return true // continue iteration
@@ -618,8 +646,9 @@ func (m *SessionLifecycleManager) checkSessionTransitions(ctx context.Context, c
 			continue
 		}
 
-		// Check if this session needs a transition
-		newState, reason := m.determineTransition(session, currentHeight, params)
+		// Check if this session needs a transition (params resolved at the session's
+		// own end height, see resolveParams above).
+		newState, reason := m.determineTransition(session, currentHeight, resolveParams(session.SessionEndHeight))
 		if newState == "" || newState == session.State {
 			noTransition++
 			continue
@@ -776,6 +805,13 @@ func (m *SessionLifecycleManager) determineTransition(
 	currentHeight int64,
 	params *sharedtypes.Params,
 ) (newState SessionState, action string) {
+	// Fail safe: without the session's epoch params we cannot compute its windows.
+	// Never fire a (possibly wrong) timeout/transition on a transient param-query
+	// failure — leave the session untouched until params resolve on a later pass.
+	if params == nil {
+		return "", ""
+	}
+
 	switch session.State {
 	case SessionStateActive:
 		// Check if session ended and claim window is approaching

--- a/miner/session_lifecycle_transition_test.go
+++ b/miner/session_lifecycle_transition_test.go
@@ -1,0 +1,91 @@
+//go:build test
+
+package miner
+
+import (
+	"testing"
+
+	"github.com/pokt-network/pocket-relay-miner/logging"
+	sharedtypes "github.com/pokt-network/poktroll/x/shared/types"
+	"github.com/stretchr/testify/require"
+)
+
+// newTransitionTestManager builds a minimal manager sufficient for exercising the
+// pure transition-decision helpers (they only use the logger plus their params arg).
+func newTransitionTestManager() *SessionLifecycleManager {
+	return &SessionLifecycleManager{
+		logger: logging.NewLoggerFromConfig(logging.DefaultConfig()),
+	}
+}
+
+// TestDetermineTransition_NilParamsFailsSafe verifies that a session whose epoch params
+// could not be resolved (GetParamsAtHeight error -> nil) is left untouched, never fired
+// into a window-timeout/transition. A transient param-query failure must not lose rewards.
+func TestDetermineTransition_NilParamsFailsSafe(t *testing.T) {
+	m := newTransitionTestManager()
+	for _, state := range []SessionState{
+		SessionStateActive, SessionStateClaiming, SessionStateClaimed, SessionStateProving,
+	} {
+		s := &SessionSnapshot{State: state, SessionEndHeight: 100, SessionStartHeight: 97}
+		newState, action := m.determineTransition(s, 1_000_000, nil)
+		require.Equal(t, SessionState(""), newState, "state=%s must not transition on nil params", state)
+		require.Equal(t, "", action, "state=%s must not transition on nil params", state)
+	}
+}
+
+// TestSessionMightNeedTransition_NilParamsFailsOpen verifies the pre-filter fails OPEN:
+// when params are unavailable the session is still selected for the full Redis-backed
+// check rather than silently skipped.
+func TestSessionMightNeedTransition_NilParamsFailsOpen(t *testing.T) {
+	m := newTransitionTestManager()
+	s := &SessionSnapshot{State: SessionStateActive, SessionEndHeight: 100, SessionStartHeight: 97}
+	require.True(t, m.sessionMightNeedTransition(s, 1, nil),
+		"pre-filter must fail open (return true) when params cannot be resolved")
+}
+
+// TestDetermineTransition_DecisionDependsOnEpochParams proves the transition decision is
+// driven by the params object passed in. The same session at the same currentHeight yields
+// a DIFFERENT decision under old-epoch vs new-epoch (different ClaimWindowOpenOffsetBlocks)
+// params — which is exactly why checkSessionTransitions now resolves params per session at
+// its own SessionEndHeight instead of using a single live snapshot.
+func TestDetermineTransition_DecisionDependsOnEpochParams(t *testing.T) {
+	m := newTransitionTestManager()
+
+	oldParams := &sharedtypes.Params{
+		NumBlocksPerSession:          4,
+		GracePeriodEndOffsetBlocks:   1,
+		ClaimWindowOpenOffsetBlocks:  1,
+		ClaimWindowCloseOffsetBlocks: 4,
+		ProofWindowOpenOffsetBlocks:  0,
+		ProofWindowCloseOffsetBlocks: 4,
+	}
+	// New epoch pushes the claim window open far later for the same sessionEndHeight.
+	newParams := &sharedtypes.Params{
+		NumBlocksPerSession:          4,
+		GracePeriodEndOffsetBlocks:   1,
+		ClaimWindowOpenOffsetBlocks:  50,
+		ClaimWindowCloseOffsetBlocks: 4,
+		ProofWindowOpenOffsetBlocks:  0,
+		ProofWindowCloseOffsetBlocks: 4,
+	}
+
+	s := &SessionSnapshot{State: SessionStateActive, SessionEndHeight: 104, SessionStartHeight: 101}
+
+	// Pick a height inside the OLD claim window.
+	oldOpen := sharedtypes.GetClaimWindowOpenHeight(oldParams, s.SessionEndHeight)
+	oldClose := sharedtypes.GetClaimWindowCloseHeight(oldParams, s.SessionEndHeight)
+	currentHeight := oldOpen
+	require.Less(t, currentHeight, oldClose, "test setup: height must be within the old claim window")
+
+	// Sanity: the new epoch's window opens strictly later, so at currentHeight it is not open yet.
+	newOpen := sharedtypes.GetClaimWindowOpenHeight(newParams, s.SessionEndHeight)
+	require.Greater(t, newOpen, currentHeight, "test setup: new-epoch window must open later")
+
+	// Under OLD-epoch params the session must move active -> claiming.
+	gotOld, _ := m.determineTransition(s, currentHeight, oldParams)
+	require.Equal(t, SessionStateClaiming, gotOld, "old-epoch params: should be in claim window")
+
+	// Under NEW-epoch params, at the same height, the window is not open yet -> no transition.
+	gotNew, _ := m.determineTransition(s, currentHeight, newParams)
+	require.Equal(t, SessionState(""), gotNew, "new-epoch params: window not open -> no transition")
+}

--- a/miner/submission_timing.go
+++ b/miner/submission_timing.go
@@ -118,7 +118,11 @@ func (c *SubmissionTimingCalculator) CalculateClaimWindow(
 	supplierOperatorAddr string,
 	windowOpenBlockHash []byte,
 ) (*SubmissionWindow, error) {
-	sharedParams, err := c.sharedClient.GetParams(ctx)
+	// Use the shared params that were effective at the session's height, not the
+	// live params. After a session-length change (poktroll #543 anchored grid),
+	// computing an old-epoch session's window with new-epoch num_blocks_per_session
+	// would resolve the wrong session grid and submit at the wrong window.
+	sharedParams, err := c.sharedClient.GetParamsAtHeight(ctx, sessionEndHeight)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get shared params: %w", err)
 	}
@@ -163,7 +167,11 @@ func (c *SubmissionTimingCalculator) CalculateProofWindow(
 	supplierOperatorAddr string,
 	windowOpenBlockHash []byte,
 ) (*SubmissionWindow, error) {
-	sharedParams, err := c.sharedClient.GetParams(ctx)
+	// Use the shared params that were effective at the session's height, not the
+	// live params. After a session-length change (poktroll #543 anchored grid),
+	// computing an old-epoch session's window with new-epoch num_blocks_per_session
+	// would resolve the wrong session grid and submit at the wrong window.
+	sharedParams, err := c.sharedClient.GetParamsAtHeight(ctx, sessionEndHeight)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get shared params: %w", err)
 	}
@@ -207,7 +215,11 @@ func (c *SubmissionTimingCalculator) WaitForClaimWindow(
 	sessionEndHeight int64,
 	supplierOperatorAddr string,
 ) (*SubmissionWindow, error) {
-	sharedParams, err := c.sharedClient.GetParams(ctx)
+	// Use the shared params that were effective at the session's height, not the
+	// live params. After a session-length change (poktroll #543 anchored grid),
+	// computing an old-epoch session's window with new-epoch num_blocks_per_session
+	// would resolve the wrong session grid and submit at the wrong window.
+	sharedParams, err := c.sharedClient.GetParamsAtHeight(ctx, sessionEndHeight)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get shared params: %w", err)
 	}
@@ -229,7 +241,11 @@ func (c *SubmissionTimingCalculator) WaitForProofWindow(
 	sessionEndHeight int64,
 	supplierOperatorAddr string,
 ) (*SubmissionWindow, error) {
-	sharedParams, err := c.sharedClient.GetParams(ctx)
+	// Use the shared params that were effective at the session's height, not the
+	// live params. After a session-length change (poktroll #543 anchored grid),
+	// computing an old-epoch session's window with new-epoch num_blocks_per_session
+	// would resolve the wrong session grid and submit at the wrong window.
+	sharedParams, err := c.sharedClient.GetParamsAtHeight(ctx, sessionEndHeight)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get shared params: %w", err)
 	}

--- a/miner/submission_timing_test.go
+++ b/miner/submission_timing_test.go
@@ -123,6 +123,56 @@ func TestTimingCalculator_CalculateClaimWindow(t *testing.T) {
 	require.Equal(t, blockHash, window.WindowOpenBlockHash)
 }
 
+// TestTimingCalculator_CalculateClaimWindow_UsesParamsAtSessionHeight proves the
+// claim window is computed from the shared params that were effective at the
+// session's height (via GetParamsAtHeight), NOT the live params. This guards the
+// poktroll #543 anchored-grid wiring: after a session-length change, an old-epoch
+// session must resolve its window with the old-epoch params.
+func TestTimingCalculator_CalculateClaimWindow_UsesParamsAtSessionHeight(t *testing.T) {
+	calc, sharedClient, _ := setupTimingCalculatorTest(t)
+
+	// Live params (default mock) use ClaimWindowOpenOffsetBlocks=1. Configure the
+	// height-aware lookup to return DIFFERENT params (offset 5) for the old session
+	// and capture the height it was queried with.
+	var gotQueryHeight int64
+	oldEpochParams := &sharedtypes.Params{
+		NumBlocksPerSession:          4,
+		GracePeriodEndOffsetBlocks:   1,
+		ClaimWindowOpenOffsetBlocks:  5,
+		ClaimWindowCloseOffsetBlocks: 4,
+		ProofWindowOpenOffsetBlocks:  0,
+		ProofWindowCloseOffsetBlocks: 4,
+	}
+	sharedClient.paramsAtHeightFn = func(_ context.Context, queryHeight int64) (*sharedtypes.Params, error) {
+		gotQueryHeight = queryHeight
+		return oldEpochParams, nil
+	}
+
+	ctx := context.Background()
+	sessionEndHeight := int64(104) // clean session boundary for numBlocksPerSession=4
+	window, err := calc.CalculateClaimWindow(ctx, sessionEndHeight, "pokt1supplier123", []byte("block-hash"))
+	require.NoError(t, err)
+	require.NotNil(t, window)
+
+	// The calculator must have queried params at the session's end height.
+	require.Equal(t, sessionEndHeight, gotQueryHeight,
+		"CalculateClaimWindow must fetch params at the session end height")
+
+	// Derive expected windows from the protocol formula using each param set, so the
+	// assertion is robust to poktroll's internal grid math. The window must match the
+	// height-aware (old-epoch) params and must differ from what live params produce.
+	liveParams, _ := sharedClient.GetParams(ctx)
+	expectedOpen := sharedtypes.GetClaimWindowOpenHeight(oldEpochParams, sessionEndHeight)
+	expectedClose := sharedtypes.GetClaimWindowCloseHeight(oldEpochParams, sessionEndHeight)
+	liveOpen := sharedtypes.GetClaimWindowOpenHeight(liveParams, sessionEndHeight)
+
+	require.NotEqual(t, liveOpen, expectedOpen,
+		"test sanity: height-aware and live params must yield different windows")
+	require.Equal(t, expectedOpen, window.WindowOpen,
+		"window must use height-aware params, not live params")
+	require.Equal(t, expectedClose, window.WindowClose)
+}
+
 // TestTimingCalculator_CalculateProofWindow removed - timing calculation integration
 // TODO(e2e): Re-implement as e2e test with testcontainers
 

--- a/query/params_query_test.go
+++ b/query/params_query_test.go
@@ -4,12 +4,147 @@ package query
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/pokt-network/pocket-relay-miner/logging"
+	sharedtypes "github.com/pokt-network/poktroll/x/shared/types"
 	"github.com/stretchr/testify/require"
 )
+
+// TestGetParamsAtHeight_DoesNotServeStaleCache is a regression guard: GetParamsAtHeight
+// must resolve through the chain's ParamsAtHeight RPC and never short-circuit on the
+// in-process GetParams cache (which is populated once and never invalidated in
+// production). Otherwise, after an on-chain MsgUpdateParam, a long-running miner returns
+// stale params for current-epoch heights and computes the wrong claim/proof windows.
+func TestGetParamsAtHeight_DoesNotServeStaleCache(t *testing.T) {
+	_, address, cleanup, mock := setupMockQueryServer(t)
+	defer cleanup()
+
+	// Live Params RPC reports the OLD epoch — this is what fills the set-once cache.
+	mock.sharedParams = &sharedtypes.Params{
+		NumBlocksPerSession:            10,
+		GracePeriodEndOffsetBlocks:     1,
+		ClaimWindowOpenOffsetBlocks:    1,
+		ClaimWindowCloseOffsetBlocks:   4,
+		ProofWindowOpenOffsetBlocks:    0,
+		ProofWindowCloseOffsetBlocks:   4,
+		ComputeUnitsToTokensMultiplier: 42,
+		SessionGridAnchorHeight:        1,
+		SessionNumberAtAnchor:          1,
+	}
+
+	logger := logging.NewLoggerFromConfig(logging.DefaultConfig())
+	qc, err := NewQueryClients(logger, ClientConfig{GRPCEndpoint: address, QueryTimeout: 5 * time.Second})
+	require.NoError(t, err)
+	defer qc.Close()
+	ctx := context.Background()
+
+	// Warm the in-process cache with the OLD epoch (a miner that booted before the change).
+	live, err := qc.Shared().GetParams(ctx)
+	require.NoError(t, err)
+	require.Equal(t, uint64(10), live.NumBlocksPerSession)
+
+	// The chain now reports a NEW epoch via ParamsAtHeight (num_blocks 10 -> 20, new anchor).
+	mock.sharedParamsAtHeight = &sharedtypes.Params{
+		NumBlocksPerSession:            20,
+		GracePeriodEndOffsetBlocks:     1,
+		ClaimWindowOpenOffsetBlocks:    1,
+		ClaimWindowCloseOffsetBlocks:   4,
+		ProofWindowOpenOffsetBlocks:    0,
+		ProofWindowCloseOffsetBlocks:   4,
+		ComputeUnitsToTokensMultiplier: 99,
+		SessionGridAnchorHeight:        100,
+		SessionNumberAtAnchor:          11,
+	}
+
+	// A current-epoch height. The stale cache has anchor=1 (<= 500), so the removed
+	// fast path would have returned the cached OLD params. The query must instead hit
+	// ParamsAtHeight and return the NEW epoch.
+	got, err := qc.Shared().GetParamsAtHeight(ctx, 500)
+	require.NoError(t, err)
+	require.Equal(t, uint64(20), got.NumBlocksPerSession,
+		"GetParamsAtHeight must resolve via ParamsAtHeight, not the stale live cache")
+	require.Equal(t, uint64(99), got.ComputeUnitsToTokensMultiplier)
+}
+
+// TestGetParamsAtHeight_CachesByHeight verifies the height-keyed memoization: a second
+// query for the same height is served from cache (no re-RPC), and a different height is
+// resolved fresh. Caching is safe because params-at-a-started-session-height are immutable.
+func TestGetParamsAtHeight_CachesByHeight(t *testing.T) {
+	_, address, cleanup, mock := setupMockQueryServer(t)
+	defer cleanup()
+
+	mkParams := func(numBlocks uint64) *sharedtypes.Params {
+		return &sharedtypes.Params{
+			NumBlocksPerSession:            numBlocks,
+			GracePeriodEndOffsetBlocks:     1,
+			ClaimWindowOpenOffsetBlocks:    1,
+			ClaimWindowCloseOffsetBlocks:   4,
+			ProofWindowOpenOffsetBlocks:    0,
+			ProofWindowCloseOffsetBlocks:   4,
+			ComputeUnitsToTokensMultiplier: 42,
+		}
+	}
+	mock.sharedParams = mkParams(10)
+	mock.sharedParamsAtHeight = mkParams(10)
+
+	logger := logging.NewLoggerFromConfig(logging.DefaultConfig())
+	qc, err := NewQueryClients(logger, ClientConfig{GRPCEndpoint: address, QueryTimeout: 5 * time.Second})
+	require.NoError(t, err)
+	defer qc.Close()
+	ctx := context.Background()
+
+	// First query at height 100 caches num_blocks=10.
+	first, err := qc.Shared().GetParamsAtHeight(ctx, 100)
+	require.NoError(t, err)
+	require.Equal(t, uint64(10), first.NumBlocksPerSession)
+
+	// Chain response changes, but height 100 must still serve the cached (immutable) value.
+	mock.sharedParamsAtHeight = mkParams(20)
+	cached, err := qc.Shared().GetParamsAtHeight(ctx, 100)
+	require.NoError(t, err)
+	require.Equal(t, uint64(10), cached.NumBlocksPerSession, "same height must be served from cache")
+
+	// A different height is resolved fresh.
+	other, err := qc.Shared().GetParamsAtHeight(ctx, 200)
+	require.NoError(t, err)
+	require.Equal(t, uint64(20), other.NumBlocksPerSession, "a new height must hit the RPC")
+}
+
+// TestGetParamsAtHeight_ConcurrentAccess exercises the height cache under the race
+// detector with simultaneous reads/writes across many heights.
+func TestGetParamsAtHeight_ConcurrentAccess(t *testing.T) {
+	_, address, cleanup, mock := setupMockQueryServer(t)
+	defer cleanup()
+
+	mock.sharedParams = generateTestSharedParams()
+	mock.sharedParamsAtHeight = generateTestSharedParams()
+
+	logger := logging.NewLoggerFromConfig(logging.DefaultConfig())
+	qc, err := NewQueryClients(logger, ClientConfig{GRPCEndpoint: address, QueryTimeout: 5 * time.Second})
+	require.NoError(t, err)
+	defer qc.Close()
+	ctx := context.Background()
+
+	var wg sync.WaitGroup
+	for g := 0; g < 16; g++ {
+		wg.Add(1)
+		go func(g int) {
+			defer wg.Done()
+			for i := 0; i < 200; i++ {
+				h := int64((i % 50) + 1) // mix of repeated (cached) and varied heights
+				p, err := qc.Shared().GetParamsAtHeight(ctx, h)
+				if err != nil || p == nil {
+					t.Errorf("GetParamsAtHeight(%d): err=%v p=%v", h, err, p)
+					return
+				}
+			}
+		}(g)
+	}
+	wg.Wait()
+}
 
 // TestGetSharedParams_Success tests successful shared params retrieval
 func TestGetSharedParams_Success(t *testing.T) {

--- a/query/query.go
+++ b/query/query.go
@@ -344,7 +344,7 @@ func (c *sharedQueryClient) GetParamsAtHeight(ctx context.Context, queryHeight i
 }
 
 func (c *sharedQueryClient) GetSessionGracePeriodEndHeight(ctx context.Context, queryHeight int64) (int64, error) {
-	params, err := c.GetParams(ctx)
+	params, err := c.GetParamsAtHeight(ctx, queryHeight)
 	if err != nil {
 		return 0, err
 	}
@@ -352,7 +352,7 @@ func (c *sharedQueryClient) GetSessionGracePeriodEndHeight(ctx context.Context, 
 }
 
 func (c *sharedQueryClient) GetClaimWindowOpenHeight(ctx context.Context, queryHeight int64) (int64, error) {
-	params, err := c.GetParams(ctx)
+	params, err := c.GetParamsAtHeight(ctx, queryHeight)
 	if err != nil {
 		return 0, err
 	}
@@ -360,7 +360,7 @@ func (c *sharedQueryClient) GetClaimWindowOpenHeight(ctx context.Context, queryH
 }
 
 func (c *sharedQueryClient) GetEarliestSupplierClaimCommitHeight(ctx context.Context, queryHeight int64, supplierOperatorAddr string) (int64, error) {
-	params, err := c.GetParams(ctx)
+	params, err := c.GetParamsAtHeight(ctx, queryHeight)
 	if err != nil {
 		return 0, err
 	}
@@ -381,7 +381,7 @@ func (c *sharedQueryClient) GetEarliestSupplierClaimCommitHeight(ctx context.Con
 }
 
 func (c *sharedQueryClient) GetProofWindowOpenHeight(ctx context.Context, queryHeight int64) (int64, error) {
-	params, err := c.GetParams(ctx)
+	params, err := c.GetParamsAtHeight(ctx, queryHeight)
 	if err != nil {
 		return 0, err
 	}
@@ -389,7 +389,7 @@ func (c *sharedQueryClient) GetProofWindowOpenHeight(ctx context.Context, queryH
 }
 
 func (c *sharedQueryClient) GetEarliestSupplierProofCommitHeight(ctx context.Context, queryHeight int64, supplierOperatorAddr string) (int64, error) {
-	params, err := c.GetParams(ctx)
+	params, err := c.GetParamsAtHeight(ctx, queryHeight)
 	if err != nil {
 		return 0, err
 	}

--- a/query/query.go
+++ b/query/query.go
@@ -265,15 +265,31 @@ type sharedQueryClient struct {
 	// Simple in-memory cache for params
 	paramsCache   *sharedtypes.Params
 	paramsCacheMu sync.RWMutex
+
+	// paramsAtHeightCache memoizes ParamsAtHeight results keyed by query height.
+	// SAFE because params-at-a-height are immutable for every height our callers query:
+	// poktroll only writes params-history entries at session boundaries (effective_height
+	// = next session start) and never mid-session, and all callers pass a started session's
+	// start/end height (<= the current session end < the next boundary). So no later
+	// param change can alter the entry resolved for such a height — the same immutability
+	// the serviceQueryClient relies on for GetServiceRelayDifficultyAtHeight.
+	paramsAtHeightCache   map[int64]*sharedtypes.Params
+	paramsAtHeightCacheMu sync.RWMutex
 }
+
+// maxParamsAtHeightCacheEntries bounds the height-keyed params cache. Entries are
+// immutable, so eviction is purely to cap memory; the lowest (oldest) heights are
+// dropped first since settled sessions are not re-queried.
+const maxParamsAtHeightCacheEntries = 1024
 
 var _ client.SharedQueryClient = (*sharedQueryClient)(nil)
 
 func newSharedQueryClient(logger logging.Logger, conn *grpc.ClientConn, timeout time.Duration) *sharedQueryClient {
 	return &sharedQueryClient{
-		logger:       logger.With().Str("query_client", "shared").Logger(),
-		queryClient:  sharedtypes.NewQueryClient(conn),
-		queryTimeout: timeout,
+		logger:              logger.With().Str("query_client", "shared").Logger(),
+		queryClient:         sharedtypes.NewQueryClient(conn),
+		queryTimeout:        timeout,
+		paramsAtHeightCache: make(map[int64]*sharedtypes.Params),
 	}
 }
 
@@ -321,17 +337,23 @@ func (c *sharedQueryClient) GetParamsAtHeight(ctx context.Context, queryHeight i
 		return c.GetParams(ctx)
 	}
 
-	// Fast path: if queryHeight falls within the current (live) params epoch, the live
-	// params ARE the params effective at queryHeight — serve them without an extra RPC.
-	// anchor <= queryHeight means queryHeight belongs to the live epoch; only an
-	// older-epoch height (queryHeight < anchor, i.e. after a recent session-length
-	// change) needs the historical lookup.
-	if liveParams, err := c.GetParams(ctx); err == nil {
-		if int64(liveParams.GetSessionGridAnchorHeight()) <= queryHeight {
-			return liveParams, nil
-		}
+	// Serve from the height-keyed cache when present (entries are immutable, see field doc).
+	c.paramsAtHeightCacheMu.RLock()
+	if cached, ok := c.paramsAtHeightCache[queryHeight]; ok {
+		c.paramsAtHeightCacheMu.RUnlock()
+		return cached, nil
 	}
+	c.paramsAtHeightCacheMu.RUnlock()
 
+	// Always resolve through the chain's ParamsAtHeight RPC. We deliberately do NOT
+	// short-circuit on c.GetParams(): paramsCache is populated once and never
+	// invalidated in production, so after an on-chain MsgUpdateParam its cached
+	// SessionGridAnchorHeight belongs to the OLD epoch. A fast path keyed on that stale
+	// anchor (anchor <= queryHeight) would be satisfied for current-epoch heights and
+	// return stale params — silently defeating the height-aware semantics this method
+	// exists for. ParamsAtHeight is authoritative: the chain returns the live params for
+	// a current-epoch height (no history entry <= height) and the historical snapshot
+	// for an older-epoch height.
 	queryCtx, cancel := context.WithTimeout(ctx, c.queryTimeout)
 	defer cancel()
 
@@ -340,7 +362,36 @@ func (c *sharedQueryClient) GetParamsAtHeight(ctx context.Context, queryHeight i
 		return nil, fmt.Errorf("failed to query shared params at height %d: %w", queryHeight, err)
 	}
 
-	return &res.Params, nil
+	params := &res.Params
+	c.storeParamsAtHeight(queryHeight, params)
+	return params, nil
+}
+
+// storeParamsAtHeight caches an immutable params-at-height entry, evicting the lowest
+// heights first when the cache is full. A single write lock guards the whole store so
+// the size check and eviction cannot race.
+func (c *sharedQueryClient) storeParamsAtHeight(height int64, params *sharedtypes.Params) {
+	c.paramsAtHeightCacheMu.Lock()
+	defer c.paramsAtHeightCacheMu.Unlock()
+
+	if c.paramsAtHeightCache == nil {
+		c.paramsAtHeightCache = make(map[int64]*sharedtypes.Params)
+	}
+
+	if _, ok := c.paramsAtHeightCache[height]; !ok && len(c.paramsAtHeightCache) >= maxParamsAtHeightCacheEntries {
+		// Evict the lowest (oldest) heights down to half capacity. Settled sessions are
+		// not re-queried, so dropping the smallest heights is the cheapest useful policy.
+		heights := make([]int64, 0, len(c.paramsAtHeightCache))
+		for h := range c.paramsAtHeightCache {
+			heights = append(heights, h)
+		}
+		sort.Slice(heights, func(i, j int) bool { return heights[i] < heights[j] })
+		for _, h := range heights[:len(heights)-maxParamsAtHeightCacheEntries/2] {
+			delete(c.paramsAtHeightCache, h)
+		}
+	}
+
+	c.paramsAtHeightCache[height] = params
 }
 
 func (c *sharedQueryClient) GetSessionGracePeriodEndHeight(ctx context.Context, queryHeight int64) (int64, error) {

--- a/query/test_helpers.go
+++ b/query/test_helpers.go
@@ -34,6 +34,10 @@ type mockQueryServer struct {
 
 	// Shared responses
 	sharedParams *sharedtypes.Params
+	// sharedParamsAtHeight, when set, is returned by the ParamsAtHeight RPC (the
+	// historical/height-aware lookup), independent of sharedParams (the live Params
+	// RPC). Lets tests simulate a chain whose live cache is stale vs the at-height value.
+	sharedParamsAtHeight *sharedtypes.Params
 
 	// Supplier responses
 	getSupplierFunc func(context.Context, *suppliertypes.QueryGetSupplierRequest) (*suppliertypes.QueryGetSupplierResponse, error)
@@ -105,6 +109,17 @@ func (m *mockSharedQueryServer) Params(ctx context.Context, req *sharedtypes.Que
 		return nil, status.Error(codes.NotFound, "params not found")
 	}
 	return &sharedtypes.QueryParamsResponse{Params: *m.mock.sharedParams}, nil
+}
+
+func (m *mockSharedQueryServer) ParamsAtHeight(ctx context.Context, req *sharedtypes.QueryParamsAtHeightRequest) (*sharedtypes.QueryParamsAtHeightResponse, error) {
+	p := m.mock.sharedParamsAtHeight
+	if p == nil {
+		p = m.mock.sharedParams
+	}
+	if p == nil {
+		return nil, status.Error(codes.NotFound, "params not found")
+	}
+	return &sharedtypes.QueryParamsAtHeightResponse{Params: *p}, nil
 }
 
 // Supplier query server implementation

--- a/tilt/config/genesis.json
+++ b/tilt/config/genesis.json
@@ -2364,6 +2364,7 @@
       "params": {
         "dao_reward_address": "pokt1eeeksh2tvkh7wzmfrljnhw4wrhs55lcuvmekkw",
         "global_inflation_per_claim": 0,
+        "mint_ratio": 1,
         "mint_allocation_percentages": {
           "application": 0,
           "dao": 0.1,

--- a/tilt/k8s/defaults.Tiltfile
+++ b/tilt/k8s/defaults.Tiltfile
@@ -12,7 +12,7 @@ def get_defaults():
         "validator": {
             "enabled": True,
             "image": "ghcr.io/pokt-network/pocketd",
-            "tag": "0.1.30",
+            "tag": "0.1.34",
             "chain_id": "pocket",
             "clean_on_restart": True,
             "ports": {


### PR DESCRIPTION
## Wire GetParamsAtHeight into session-bounded param reads

Builds on the 0.1.34 bump. 0.1.34 added `GetParamsAtHeight` to `SharedQueryClient` and made the shared params session-bounded (the chain snapshots params per epoch and resolves each computation at the session's height). We implemented the method to compile but never called it — everything still read live `GetParams`. After a `num_blocks_per_session` / window-offset / CUTTM change (#543 anchored grid) with sessions in flight, an old-epoch session computed with live params resolves the wrong window or reward.

Routes the session-bound reads through `GetParamsAtHeight`:

- Claim/proof window timing → `GetParamsAtHeight(sessionEndHeight)` (submission_timing, claim/proof pipelines, inclusion_tracker, query wrappers)
- Reward (`getClaimReward`) and proof-requirement → shared params at `sessionStartHeight`, matching `msg_server_create_claim` / `ProofRequirementForClaim`. Proof params stay live, like the chain.
- Lifecycle transition filter → per-session params at `sessionEndHeight`, fail-open/fail-safe on query error.

`GetParamsAtHeight` resolves through the chain's `ParamsAtHeight` RPC. It does NOT short-circuit on the in-process `GetParams` cache, which is populated once and never invalidated in production — a fast path keyed on its stale anchor returned stale params for current-epoch heights after a governance change (cross-AI review finding). Results are memoized in a bounded height-keyed cache: params at a started-session height are immutable (poktroll writes params-history only at session boundaries, never mid-session), so this is safe and skips re-querying the same height.

Left live on purpose (matches chain/upstream): relay_meter, rings (must match the chain's verifier), GetSession cache key, params_refresher, cache TTLs. Removed dead `SessionLifecycleManager.sharedParams` state orphaned by the per-session change (kept a boot-time reachability check).

Also bumps the localnet to run 0.1.34: validator image 0.1.30 → 0.1.34, and adds `mint_ratio: 1` to the genesis tokenomics params (new in 0.1.34; without it `TLMRelayBurnEqualsMint` mints zero and discards every claim).

## Testing

- `make lint` clean; `go test -race ./miner/... ./query/...` green. Tests: window/transition computations use the session-epoch params (not live); `GetParamsAtHeight` does not serve the stale live cache; caches by height; concurrent-access race; lifecycle fail-open/fail-safe.
- Each call site checked against the poktroll v0.1.34 source (verified the tag, not main).
- Live on a 0.1.34 localnet under load, with governance param changes mid-flight (num_blocks 10→20, claim_window_open_offset 1→6, CUTTM 100→200→400), 0 discards throughout:
  - Timing: the miner's own computed `claim_window_open` moved from sessionEnd+2 (claimOpen=1, old-epoch sessions) to sessionEnd+7 (claimOpen=6, new-epoch sessions) — each session's window computed with its own epoch's offset.
  - Economic: on-chain settlement reward matched each session's epoch CUTTM (implied CUTTM 100 → 200 → 400 across consecutive session epochs).
  - Full relay → claim → proof → settlement; 15/15 suppliers settle per session with correct relays/CU and the configured reward split (supplier 70% / source-owner 15% / DAO 10% / proposer 5%).

Note (poktroll behavior, not this repo): chaining separate `MsgUpdateParam` txs in one session silently drops all but the last session-timing change (documented MED2 limitation in x/shared); use the bulk `MsgUpdateParams`.
