### PR TITLE
feat(relayer): probe-only headers on backend health checks

### DIFF
--- a/config.relayer.example.yaml
+++ b/config.relayer.example.yaml
@@ -107,6 +107,10 @@ services:
         #   timeout_seconds: 5
         #   unhealthy_threshold: 5
         #   healthy_threshold: 3
+        #   # Probe-only headers, merged over the pool headers above (probe wins
+        #   # on conflict). Use for a health-check token not sent on real relays:
+        #   headers:
+        #     X-Health-Token: "probe-only-secret"
         #
         # Recovery timeout: auto-recover circuit-breaker-tripped backends after N seconds.
         # Prevents death spiral when all backends are unhealthy and no health checks are configured.

--- a/config.relayer.schema.yaml
+++ b/config.relayer.schema.yaml
@@ -275,6 +275,16 @@ properties:
                     type: integer
                     description: Successes before marking healthy
                     minimum: 1
+                  headers:
+                    type: object
+                    description: >-
+                      Headers applied only to health check probe requests.
+                      Merged on top of the pool-level backend headers; a key
+                      here overrides the same key from the pool for the probe
+                      only. Use for probe-specific headers (e.g. a health-check
+                      auth token) not sent on real relay traffic.
+                    additionalProperties:
+                      type: string
 
   default_validation_mode:
     type: string

--- a/relayer/config.go
+++ b/relayer/config.go
@@ -489,6 +489,13 @@ type BackendHealthCheckConfig struct {
 	// ExpectedStatus is a list of acceptable HTTP status codes.
 	// If not set, any 2xx status code (200-299) is considered healthy.
 	ExpectedStatus []int `yaml:"expected_status,omitempty"`
+
+	// Headers are additional headers applied only to health check probe requests.
+	// They are merged on top of the pool-level BackendConfig.Headers, so a key
+	// present here overrides the same key from the pool for the probe only.
+	// Use this for probe-specific headers (e.g. a health-check auth token) that
+	// should not be sent on real relay traffic.
+	Headers map[string]string `yaml:"headers,omitempty"`
 }
 
 // MetricsConfig contains metrics server configuration.

--- a/relayer/healthcheck.go
+++ b/relayer/healthcheck.go
@@ -415,6 +415,14 @@ func buildProbeRequest(ctx context.Context, healthURL string, config *BackendHea
 		}
 	}
 
+	// Apply health-check-specific headers on top of pool headers.
+	// A key present here overrides the same key from the pool for the probe only.
+	if config.Headers != nil {
+		for k, v := range config.Headers {
+			req.Header.Set(k, v)
+		}
+	}
+
 	// Apply pool-level authentication
 	if backend.auth != nil {
 		if backend.auth.BearerToken != "" {

--- a/relayer/healthcheck_test.go
+++ b/relayer/healthcheck_test.go
@@ -437,6 +437,62 @@ func TestHealthCheck_PoolHeaders(t *testing.T) {
 	assert.Equal(t, "value456", receivedCustom)
 }
 
+func TestHealthCheck_ConfigHeaders(t *testing.T) {
+	// Probe request includes headers defined directly on the health check config,
+	// independent of any pool-level headers.
+	var receivedToken string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedToken = r.Header.Get("X-Health-Token")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	hc := newTestHealthChecker()
+	ep := newTestEndpoint(server.URL)
+	config := defaultConfig()
+	config.Headers = map[string]string{
+		"X-Health-Token": "probe-only-secret",
+	}
+
+	// No pool-level headers passed (nil) — header must come from the config alone.
+	hc.RegisterPool("svc:jsonrpc", []*pool.BackendEndpoint{ep}, config, nil, nil, "")
+	hc.checkPool(context.Background(), "svc:jsonrpc", config)
+
+	assert.Equal(t, "probe-only-secret", receivedToken)
+}
+
+func TestHealthCheck_ConfigHeadersOverridePoolHeaders(t *testing.T) {
+	// When the same header key is present in both pool headers and health check
+	// config headers, the health check config value wins for the probe.
+	var receivedOverridden string
+	var receivedPoolOnly string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedOverridden = r.Header.Get("X-Shared")
+		receivedPoolOnly = r.Header.Get("X-Pool-Only")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	hc := newTestHealthChecker()
+	ep := newTestEndpoint(server.URL)
+	config := defaultConfig()
+	config.Headers = map[string]string{
+		"X-Shared": "from-health-check",
+	}
+	poolHeaders := map[string]string{
+		"X-Shared":    "from-pool",
+		"X-Pool-Only": "pool-value",
+	}
+
+	hc.RegisterPool("svc:jsonrpc", []*pool.BackendEndpoint{ep}, config, poolHeaders, nil, "")
+	hc.checkPool(context.Background(), "svc:jsonrpc", config)
+
+	// Health check config header wins on conflict.
+	assert.Equal(t, "from-health-check", receivedOverridden)
+	// Non-conflicting pool header is still applied.
+	assert.Equal(t, "pool-value", receivedPoolOnly)
+}
+
 // --- Reset and State Tests ---
 
 func TestHealthCheck_FullResetOnRecovery(t *testing.T) {


### PR DESCRIPTION
## What

Adds an optional `headers` map to a backend's `health_check` config so operators can send headers on the **active health check probe** that are **not** sent on real relay traffic — e.g. a health-check auth token gated to the probe.

## Why

Today the probe only inherits the pool-level `backend.headers` / `backend.authentication` (shared with real traffic). There was no way to attach a header to the probe alone. Confirmed there was no existing field for this.

## How

- New field `Headers map[string]string` on `BackendHealthCheckConfig` (`relayer/config.go`).
- `buildProbeRequest` merges it **on top of** the pool headers, so a key present in the health check config overrides the same key from the pool **for the probe only** (`relayer/healthcheck.go`).
- `buildProbeRequest` already received the `*BackendHealthCheckConfig`, so **no `RegisterPool` signature change** was needed.
- Precedence: pool headers → health-check headers (win on conflict) → pool auth (unchanged, still applied last).

### Config example

```yaml
backends:
  "3":
    url: http://backend:8080
    headers:
      X-Api-Key: "shared"          # sent on every real relay
    health_check:
      enabled: true
      endpoint: /health
      headers:
        X-Health-Token: "probe-only-secret"   # sent only on the probe
```

## Tests (TDD)

- `TestHealthCheck_ConfigHeaders` — probe sends config-only headers (no pool headers present).
- `TestHealthCheck_ConfigHeadersOverridePoolHeaders` — config header wins over pool header on conflict; non-conflicting pool header still applied.

Both written test-first (watched fail on `config.Headers undefined`, then green).

## Quality gates

- `go build ./...` clean
- `go vet ./relayer/` clean
- `gofmt -l` empty
- `go test -tags test -race ./relayer/` pass
- `golangci-lint run ./relayer/...` → 0 issues

## Independent of the protocol upgrade

This change is **not** blocked by the poktroll 0.1.34 upgrade (#9) or the GetParamsAtHeight wiring (#10). It touches only `relayer/config.go`, `relayer/healthcheck.go`, tests, and config docs, and verified to cherry-pick cleanly onto `main` with build + race tests passing. Targets `main` directly so it can be released independently; #9/#10 do not need to land first.

## Notes for reviewer

- **Pre-existing, not touched here:** the per-backend `health_check` block in `config.relayer.schema.yaml` was already missing `method`, `request_body`, `content_type`, `expected_body`, `expected_status` (all already supported by the Go struct). Happy to sync the schema for those in a follow-up if wanted.