### PR TITLE
fix(websocket): preserve frame type across the bridge, bound frame size and write duration

### DIFF
--- a/cmd/relay/websocket.go
+++ b/cmd/relay/websocket.go
@@ -84,13 +84,11 @@ func runWebSocketDiagnostic(ctx context.Context, logger logging.Logger, relayCli
 
 		// Receive relay response
 		_ = conn.SetReadDeadline(time.Now().Add(5 * time.Second))
-		messageType, responseData, err := conn.ReadMessage()
+		// The frame type is whatever the relayer echoed back from the backend, so
+		// it carries no information about the response and is deliberately ignored.
+		_, responseData, err := conn.ReadMessage()
 		if err != nil {
 			return nil, fmt.Errorf("failed to read relay response: %w", err)
-		}
-
-		if messageType != websocket.BinaryMessage {
-			return nil, fmt.Errorf("unexpected message type: %d (expected binary)", messageType)
 		}
 
 		return responseData, nil

--- a/relayer/websocket.go
+++ b/relayer/websocket.go
@@ -34,6 +34,29 @@ const (
 	defaultWSDialTimeout = 10 * time.Second
 )
 
+// wsMaxMessageBytes caps a single inbound WebSocket frame on both the gateway
+// and backend connections.
+//
+// gorilla buffers an entire frame in memory before ReadMessage returns and its
+// default limit is unlimited, so one oversized frame OOMs the process. On the
+// gateway side this is reachable pre-auth by anyone: CheckOrigin accepts every
+// origin, validateAndLogWebSocketHandshake is permissive by design and never
+// rejects, and readLoop allocates the frame before handleGatewayMessage checks
+// a ring signature -- so the attacker needs no key, no stake, and no session.
+// The backend side is bounded too, since a compromised or hostile backend can
+// send an abusive frame just as easily.
+//
+// 15MB matches PATH's maxMessageBytes and go-ethereum's wsMessageSizeLimit,
+// which is what the EVM backends behind this relayer enforce on their own
+// output. Matching the rest of the stack is deliberate: a tighter cap here
+// would reject frames PATH already accepted and forwarded, reintroducing the
+// class of cross-component divergence this bridge exists to avoid.
+//
+// When exceeded, gorilla sends a 1009 (message too big) close frame and
+// ReadMessage errors, so readLoop tears the bridge down through its existing
+// close path.
+const wsMaxMessageBytes = 15 * 1024 * 1024
+
 // RFC 6455 WebSocket Close Codes
 // https://datatracker.ietf.org/doc/html/rfc6455#section-7.4.1
 const (
@@ -249,6 +272,12 @@ func NewWebSocketBridge(
 		cancelFn()
 		return nil, err
 	}
+
+	// Bound inbound frame size on both connections before either readLoop starts.
+	// Either peer can send an abusive frame, and the gateway side is reachable
+	// pre-auth -- see wsMaxMessageBytes.
+	gatewayConn.SetReadLimit(wsMaxMessageBytes)
+	backendConn.SetReadLimit(wsMaxMessageBytes)
 
 	bridge := &WebSocketBridge{
 		logger:           logger.With().Str(logging.FieldComponent, logging.ComponentWebsocketBridge).Str(logging.FieldServiceID, serviceID).Logger(),
@@ -487,6 +516,45 @@ func (b *WebSocketBridge) messageLoop() {
 	}
 }
 
+// writeDataFrame sets a write deadline and then writes a data frame to conn,
+// serialised on writeMu.
+//
+// gorilla's WriteMessage does not observe a context and blocks indefinitely once
+// the peer stops reading and its TCP receive buffer fills. Every data frame is
+// written from the single messageLoop goroutine and serialised on writeMu, so
+// one stalled peer would wedge the entire bridge: messageLoop can never reach
+// its ctx.Done() select while blocked in a write, which means pingLoop
+// cancelling the context cannot free it, and the connection holds its resources
+// until the OS-level TCP timeout. The deadline bounds that wait so a stalled
+// reader fails fast and the bridge tears down through its normal path.
+//
+// The deadline is set under writeMu because SetWriteDeadline and WriteMessage
+// must apply as a pair -- another writer setting its own deadline in between
+// would write under the wrong one. Control writes (ping/close) pass their own
+// deadline to WriteControl and do not need this.
+//
+// writeWait is a parameter rather than a direct read of wsWriteWait so a test
+// can drive the stalled-peer path in milliseconds instead of ten seconds.
+func writeDataFrame(conn *websocket.Conn, writeMu *sync.Mutex, messageType int, data []byte, writeWait time.Duration) error {
+	writeMu.Lock()
+	defer writeMu.Unlock()
+
+	if err := conn.SetWriteDeadline(time.Now().Add(writeWait)); err != nil {
+		return err
+	}
+	return conn.WriteMessage(messageType, data)
+}
+
+// writeToGateway writes a data frame to the gateway (PATH) connection.
+func (b *WebSocketBridge) writeToGateway(messageType int, data []byte) error {
+	return writeDataFrame(b.gatewayConn, &b.gatewayWriteMu, messageType, data, wsWriteWait)
+}
+
+// writeToBackend writes a data frame to the backend connection.
+func (b *WebSocketBridge) writeToBackend(messageType int, data []byte) error {
+	return writeDataFrame(b.backendConn, &b.backendWriteMu, messageType, data, wsWriteWait)
+}
+
 // handleGatewayMessage handles messages from the gateway.
 func (b *WebSocketBridge) handleGatewayMessage(msg wsMessage) {
 	wsMessagesForwarded.WithLabelValues(b.serviceID, "gateway_to_backend").Inc()
@@ -608,9 +676,7 @@ func (b *WebSocketBridge) handleGatewayMessage(msg wsMessage) {
 	// only channel for it: hardcoding a type here destroys information nothing
 	// downstream can reconstruct. Text-only JSON-RPC backends reject binary
 	// frames. Matches poktroll, PATH, and the raw forwarding paths below.
-	b.backendWriteMu.Lock()
-	err := b.backendConn.WriteMessage(msg.messageType, relayReq.Payload)
-	b.backendWriteMu.Unlock()
+	err := b.writeToBackend(msg.messageType, relayReq.Payload)
 	if err != nil {
 		b.logger.Warn().Err(err).Msg("failed to forward to backend")
 		_ = b.closeWithReason(CloseInternalError, "backend write failed", wsCloseInitiatorRelayer)
@@ -637,9 +703,7 @@ func (b *WebSocketBridge) handleBackendMessage(msg wsMessage) {
 	if latestReq == nil {
 		b.logger.Debug().Msg("no latestRequest - forwarding raw to gateway")
 		// No request yet - just forward raw data
-		b.gatewayWriteMu.Lock()
-		err := b.gatewayConn.WriteMessage(msg.messageType, msg.data)
-		b.gatewayWriteMu.Unlock()
+		err := b.writeToGateway(msg.messageType, msg.data)
 		if err != nil {
 			b.logger.Warn().Err(err).Msg("failed to forward to client (PATH)")
 			_ = b.closeWithReason(CloseInternalError, "client write failed", wsCloseInitiatorRelayer)
@@ -679,9 +743,7 @@ func (b *WebSocketBridge) handleBackendMessage(msg wsMessage) {
 	// sent. Backend frames cannot be paired with client frames (one eth_subscribe
 	// yields N pushes), so each hop echoes its own inbound type instead. A browser
 	// doing JSON.parse(e.data) needs text to survive the round trip.
-	b.gatewayWriteMu.Lock()
-	writeErr := b.gatewayConn.WriteMessage(msg.messageType, respBytes)
-	b.gatewayWriteMu.Unlock()
+	writeErr := b.writeToGateway(msg.messageType, respBytes)
 	if writeErr != nil {
 		b.logger.Warn().Err(writeErr).Msg("failed to forward signed response to client (PATH)")
 		_ = b.closeWithReason(CloseInternalError, "client write failed", wsCloseInitiatorRelayer)
@@ -702,9 +764,7 @@ func (b *WebSocketBridge) handleBackendMessage(msg wsMessage) {
 
 // forwardToBackend forwards a raw message to the backend.
 func (b *WebSocketBridge) forwardToBackend(msg wsMessage) {
-	b.backendWriteMu.Lock()
-	err := b.backendConn.WriteMessage(msg.messageType, msg.data)
-	b.backendWriteMu.Unlock()
+	err := b.writeToBackend(msg.messageType, msg.data)
 	if err != nil {
 		b.logger.Warn().Err(err).Msg("failed to forward raw message to backend")
 		_ = b.closeWithReason(CloseInternalError, "backend write failed", wsCloseInitiatorRelayer)
@@ -831,10 +891,10 @@ func (b *WebSocketBridge) sendSessionExpirationMessage() error {
 		return err
 	}
 
-	// Send to gateway as BinaryMessage (protobuf format)
-	b.gatewayWriteMu.Lock()
-	err = b.gatewayConn.WriteMessage(websocket.BinaryMessage, respBytes)
-	b.gatewayWriteMu.Unlock()
+	// Sent as BinaryMessage rather than an echoed type: this frame is initiated
+	// by the relayer on session expiry, not in response to an inbound frame, so
+	// there is no type to echo. See writeToGateway for the deadline rationale.
+	err = b.writeToGateway(websocket.BinaryMessage, respBytes)
 	if err != nil {
 		return err
 	}

--- a/relayer/websocket.go
+++ b/relayer/websocket.go
@@ -603,10 +603,13 @@ func (b *WebSocketBridge) handleGatewayMessage(msg wsMessage) {
 		Str("payload_preview", string(relayReq.Payload[:min(50, len(relayReq.Payload))])).
 		Msg("forwarding payload to backend")
 
-	// Forward payload to backend as BinaryMessage (transport-agnostic opaque bytes)
-	// The relayer doesn't inspect or care about the payload format (JSON, protobuf, etc.)
+	// Forward payload to backend echoing the frame type the client sent.
+	// No relay protobuf carries a frame type, so the WebSocket envelope is the
+	// only channel for it: hardcoding a type here destroys information nothing
+	// downstream can reconstruct. Text-only JSON-RPC backends reject binary
+	// frames. Matches poktroll, PATH, and the raw forwarding paths below.
 	b.backendWriteMu.Lock()
-	err := b.backendConn.WriteMessage(websocket.BinaryMessage, relayReq.Payload)
+	err := b.backendConn.WriteMessage(msg.messageType, relayReq.Payload)
 	b.backendWriteMu.Unlock()
 	if err != nil {
 		b.logger.Warn().Err(err).Msg("failed to forward to backend")
@@ -672,10 +675,12 @@ func (b *WebSocketBridge) handleBackendMessage(msg wsMessage) {
 	// Store latest response for relay emission
 	b.setLatestResponse(relayResp)
 
-	// Forward signed RelayResponse to gateway as BinaryMessage (protobuf format)
-	// Always use BinaryMessage for RelayResponse (protobuf is binary data)
+	// Forward signed RelayResponse to gateway echoing the frame type the backend
+	// sent. Backend frames cannot be paired with client frames (one eth_subscribe
+	// yields N pushes), so each hop echoes its own inbound type instead. A browser
+	// doing JSON.parse(e.data) needs text to survive the round trip.
 	b.gatewayWriteMu.Lock()
-	writeErr := b.gatewayConn.WriteMessage(websocket.BinaryMessage, respBytes)
+	writeErr := b.gatewayConn.WriteMessage(msg.messageType, respBytes)
 	b.gatewayWriteMu.Unlock()
 	if writeErr != nil {
 		b.logger.Warn().Err(writeErr).Msg("failed to forward signed response to client (PATH)")

--- a/relayer/websocket_frametype_test.go
+++ b/relayer/websocket_frametype_test.go
@@ -1,0 +1,88 @@
+//go:build test
+
+package relayer
+
+import (
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+	servicetypes "github.com/pokt-network/poktroll/x/service/types"
+	"github.com/stretchr/testify/require"
+)
+
+// awaitBackendFrameType returns the frame type of the next message the fake
+// backend received, failing the test rather than hanging if none arrives.
+func awaitBackendFrameType(t *testing.T, f *simWSFixture) int {
+	t.Helper()
+	select {
+	case mt := <-f.backendTypes:
+		return mt
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for the backend to receive a frame")
+		return 0
+	}
+}
+
+// assertFrameTypeRoundTrip drives one relay through a real bridge and proves
+// the frame type survives both hops: the type the client sent is the type the
+// backend receives, and the type the backend replied with is the type the
+// gateway receives.
+//
+// This is a regression test for the bridge hardcoding websocket.BinaryMessage
+// on both data-frame writes. No relay protobuf carries a frame type, so the
+// WebSocket envelope is the only channel for it -- a hardcoded write destroys
+// information nothing downstream can rebuild. It ran text-only against the
+// gateway hop as well, so a browser doing JSON.parse(e.data) got a Blob and
+// threw. Both directions are covered so the fix cannot degenerate into
+// hardcoding TextMessage instead.
+//
+// Each hop echoes the type it just read from that side; the two hops are
+// asserted independently because they cannot be paired -- one eth_subscribe
+// request yields N backend pushes. This mirrors poktroll
+// (pkg/relayer/proxy/websockets/bridge.go) and PATH (websockets/bridge.go),
+// both of which preserve symmetrically.
+func assertFrameTypeRoundTrip(t *testing.T, frameType int) {
+	t.Helper()
+	f := newSimWSFixture(t)
+
+	rr := f.buildSignedRelay(t, FormatSimSessionID(f.clock(), "frametype"))
+	bz, err := rr.Marshal()
+	require.NoError(t, err)
+
+	require.NoError(t, f.gwClient.WriteMessage(frameType, bz))
+
+	// Hop 1: client -> backend. The fake backend echoes the type it read, so
+	// this also sets up hop 2's inbound type.
+	require.Equal(t, frameType, awaitBackendFrameType(t, f),
+		"backend must receive the frame type the client sent, not a hardcoded one")
+
+	// Hop 2: backend -> gateway.
+	require.NoError(t, f.gwClient.SetReadDeadline(time.Now().Add(5*time.Second)))
+	gotType, respBz, err := f.gwClient.ReadMessage()
+	require.NoError(t, err)
+	require.Equal(t, frameType, gotType,
+		"gateway must receive the frame type the backend replied with, not a hardcoded one")
+
+	// The frame is still a signed RelayResponse: preserving the type must not
+	// change what is carried. A binary protobuf riding a text frame is the
+	// whole stack's load-bearing hack (RFC 6455 5.6 wants text frames to be
+	// valid UTF-8; nothing in this stack validates it) -- matching poktroll is
+	// the point, so this asserts the payload survives rather than objecting.
+	var resp servicetypes.RelayResponse
+	require.NoError(t, resp.Unmarshal(respBz), "response must unmarshal as a RelayResponse")
+	require.NotEmpty(t, resp.Meta.SupplierOperatorSignature, "response must still be supplier-signed")
+	require.Contains(t, string(resp.Payload), `"result":"0x1"`, "response must carry the backend payload")
+}
+
+// TestWebSocketBridge_PreservesTextFrameType is the case the hardcoded
+// BinaryMessage broke: a text-sending client (any browser) got binary back.
+func TestWebSocketBridge_PreservesTextFrameType(t *testing.T) {
+	assertFrameTypeRoundTrip(t, websocket.TextMessage)
+}
+
+// TestWebSocketBridge_PreservesBinaryFrameType pins the other half, so the fix
+// is "echo the inbound type" and not "hardcode the other constant".
+func TestWebSocketBridge_PreservesBinaryFrameType(t *testing.T) {
+	assertFrameTypeRoundTrip(t, websocket.BinaryMessage)
+}

--- a/relayer/websocket_readlimit_test.go
+++ b/relayer/websocket_readlimit_test.go
@@ -1,0 +1,77 @@
+//go:build test
+
+package relayer
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"github.com/stretchr/testify/require"
+)
+
+// TestWebSocketBridge_OversizedGatewayFrameRejected proves an inbound frame
+// larger than wsMaxMessageBytes is refused and the bridge torn down, rather
+// than being buffered whole in memory.
+//
+// This is the pre-auth OOM path: gorilla's default read limit is unlimited and
+// readLoop allocates the frame before handleGatewayMessage checks a ring
+// signature, so any unauthenticated peer (CheckOrigin accepts every origin,
+// validateAndLogWebSocketHandshake never rejects) could OOM the relayer with a
+// single frame.
+//
+// The frame is deliberately unparseable as a RelayRequest, which routes it down
+// handleGatewayMessage's raw forwardToBackend path. That makes backendHits the
+// load-bearing assertion: with no read limit the oversized frame is forwarded
+// to the backend, so this test fails without the fix rather than passing on a
+// technicality.
+func TestWebSocketBridge_OversizedGatewayFrameRejected(t *testing.T) {
+	f := newSimWSFixture(t)
+
+	// 0xFF bytes cannot decode as a protobuf RelayRequest (0xFF is an unending
+	// varint continuation), guaranteeing the raw-forward path.
+	oversized := bytes.Repeat([]byte{0xFF}, wsMaxMessageBytes+1024)
+
+	// The write may fail rather than succeed: the relayer stops reading and
+	// closes as soon as the limit is passed, so the client can see a broken
+	// pipe mid-write. Both outcomes mean the frame was refused, so the write
+	// result is not asserted -- the close code and the backend are.
+	_ = f.gwClient.SetWriteDeadline(time.Now().Add(10 * time.Second))
+	_ = f.gwClient.WriteMessage(websocket.BinaryMessage, oversized)
+
+	require.NoError(t, f.gwClient.SetReadDeadline(time.Now().Add(10*time.Second)))
+	_, _, err := f.gwClient.ReadMessage()
+	require.Error(t, err, "relayer must close the connection on an oversized frame")
+
+	// 1009 is gorilla's specific response to exceeding the read limit. Asserting
+	// the code (not merely "an error") proves the read limit is what rejected
+	// the frame, rather than the connection dying for an unrelated reason.
+	require.True(t, websocket.IsCloseError(err, CloseMessageTooBig),
+		"connection must close with 1009 (message too big), got: %v", err)
+
+	require.Equal(t, int32(0), f.backendHits.Load(),
+		"an oversized frame must never reach the backend")
+}
+
+// TestWebSocketBridge_MaxSizeFrameStillAccepted pins the boundary from the
+// other side: a large frame under the cap must still be served. A limit set too
+// low (or off by an order of magnitude) would pass the rejection test above
+// while silently breaking legitimate large responses, which is the expensive
+// failure -- it looks like the backend misbehaving, not like a cap.
+func TestWebSocketBridge_MaxSizeFrameStillAccepted(t *testing.T) {
+	f := newSimWSFixture(t)
+
+	// Comfortably large (1MB) but well under the 15MB cap: proves the limit is
+	// not merely rejecting anything bigger than a typical relay payload.
+	large := bytes.Repeat([]byte{0xFF}, 1<<20)
+
+	require.NoError(t, f.gwClient.SetWriteDeadline(time.Now().Add(10*time.Second)))
+	require.NoError(t, f.gwClient.WriteMessage(websocket.BinaryMessage, large),
+		"a 1MB frame is under the cap and must be accepted")
+
+	// Unparseable as a RelayRequest, so it is raw-forwarded: the backend
+	// receiving it is the proof the frame survived the read limit.
+	require.Equal(t, websocket.BinaryMessage, awaitBackendFrameType(t, f),
+		"a frame under the cap must be forwarded to the backend")
+}

--- a/relayer/websocket_simulation_test.go
+++ b/relayer/websocket_simulation_test.go
@@ -55,11 +55,16 @@ func (v *neverCallValidator) CheckRewardEligibility(context.Context, *servicetyp
 func (v *neverCallValidator) GetCurrentBlockHeight() int64 { return 0 }
 func (v *neverCallValidator) SetCurrentBlockHeight(int64)  {}
 
-// newSimWSBackendServer starts a fake WebSocket backend: every BinaryMessage
-// it receives increments hits and gets a canned JSON-RPC-shaped reply.
-func newSimWSBackendServer(t *testing.T) (wsURL string, hits *atomic.Int32) {
+// newSimWSBackendServer starts a fake WebSocket backend: every message it
+// receives increments hits and gets a canned JSON-RPC-shaped reply, echoed
+// back with the same frame type it arrived on (what a real backend does).
+// Each received frame type is also published on gotTypes so a test can assert
+// which type the bridge forwarded; sends are non-blocking, so a test that
+// ignores gotTypes never stalls the backend.
+func newSimWSBackendServer(t *testing.T) (wsURL string, hits *atomic.Int32, gotTypes chan int) {
 	t.Helper()
 	hits = &atomic.Int32{}
+	gotTypes = make(chan int, 16)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		conn, err := WebSocketUpgrader.Upgrade(w, r, nil)
 		if err != nil {
@@ -72,6 +77,10 @@ func newSimWSBackendServer(t *testing.T) (wsURL string, hits *atomic.Int32) {
 				return
 			}
 			n := hits.Add(1)
+			select {
+			case gotTypes <- mt:
+			default:
+			}
 			reply := []byte(fmt.Sprintf(`{"jsonrpc":"2.0","result":"0x%d","id":1}`, n))
 			if err := conn.WriteMessage(mt, reply); err != nil {
 				return
@@ -79,7 +88,7 @@ func newSimWSBackendServer(t *testing.T) (wsURL string, hits *atomic.Int32) {
 		}
 	}))
 	t.Cleanup(srv.Close)
-	return "ws" + strings.TrimPrefix(srv.URL, "http"), hits
+	return "ws" + strings.TrimPrefix(srv.URL, "http"), hits, gotTypes
 }
 
 // newGatewaySideHarness stands in for the PATH gateway's side of the
@@ -120,6 +129,7 @@ func newGatewaySideHarness(t *testing.T) (relayerSide, testSide *websocket.Conn)
 type simWSFixture struct {
 	gwClient     *websocket.Conn
 	backendHits  *atomic.Int32
+	backendTypes chan int
 	pub          *recordingPublisher
 	proc         *recordingProcessor
 	validator    *neverCallValidator
@@ -178,7 +188,7 @@ func newSimWSFixture(t *testing.T) *simWSFixture {
 	// dereferenced even if the simulated guard were broken.
 	pipeline := NewRelayPipeline(validator, nil, signer, proc, logger, nil, nil)
 
-	backendURL, backendHits := newSimWSBackendServer(t)
+	backendURL, backendHits, backendTypes := newSimWSBackendServer(t)
 	relayerConn, gwClient := newGatewaySideHarness(t)
 	t.Cleanup(func() { _ = gwClient.Close() })
 
@@ -209,6 +219,7 @@ func newSimWSFixture(t *testing.T) *simWSFixture {
 	return &simWSFixture{
 		gwClient:     gwClient,
 		backendHits:  backendHits,
+		backendTypes: backendTypes,
 		pub:          pub,
 		proc:         proc,
 		validator:    validator,

--- a/relayer/websocket_writedeadline_test.go
+++ b/relayer/websocket_writedeadline_test.go
@@ -1,0 +1,136 @@
+//go:build test
+
+package relayer
+
+import (
+	"errors"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"github.com/stretchr/testify/require"
+)
+
+// newStalledPeerConn returns a client connection to a WebSocket server that
+// completes the handshake and then never reads a single frame, holding the
+// connection open until the test ends. This is the shape of a real stalled
+// reader: the peer is alive at the TCP level, so nothing errors, but its
+// receive buffer fills and never drains.
+func newStalledPeerConn(t *testing.T) *websocket.Conn {
+	t.Helper()
+
+	release := make(chan struct{})
+	t.Cleanup(func() { close(release) })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := WebSocketUpgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		// Deliberately never call ReadMessage. Block until the test is done so
+		// the connection stays open rather than being torn down by the handler
+		// returning -- a closed peer would produce a write error for the wrong
+		// reason and make this test pass vacuously.
+		<-release
+	}))
+	t.Cleanup(srv.Close)
+
+	client, _, err := websocket.DefaultDialer.Dial("ws"+strings.TrimPrefix(srv.URL, "http"), nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = client.Close() })
+
+	return client
+}
+
+// TestWriteDataFrame_StalledPeerTimesOut proves a peer that stops reading
+// cannot block a data-frame write forever.
+//
+// Without the deadline, gorilla's WriteMessage blocks indefinitely once the
+// stalled peer's receive buffer fills: it does not observe a context, so the
+// bridge's single messageLoop goroutine can never reach its ctx.Done() select,
+// pingLoop cancelling the context cannot free it, and because every write is
+// serialised on the same mutex the whole bridge wedges until the OS-level TCP
+// timeout. This test would hang rather than fail if the deadline were removed,
+// which is why it drives a real stalled peer instead of asserting on the
+// deadline value.
+func TestWriteDataFrame_StalledPeerTimesOut(t *testing.T) {
+	conn := newStalledPeerConn(t)
+
+	var mu sync.Mutex
+	// 1MB per frame: kernel socket buffers are finite but can hold a few
+	// hundred KB, so the write only blocks once they are full. Looping is what
+	// makes this deterministic -- the peer never drains, so buffers cannot
+	// recover and some iteration must block into the deadline.
+	chunk := make([]byte, 1<<20)
+
+	var err error
+	deadline := time.Now().Add(30 * time.Second)
+	for i := 0; i < 256; i++ {
+		if err = writeDataFrame(conn, &mu, websocket.BinaryMessage, chunk, 50*time.Millisecond); err != nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("writes kept succeeding against a peer that never reads: the write deadline is not bounding the write")
+		}
+	}
+
+	require.Error(t, err, "a write to a stalled peer must eventually fail rather than block forever")
+
+	// Assert it failed for the right reason. Any error would satisfy the check
+	// above -- only a timeout proves the deadline is what stopped it, rather
+	// than the connection dying for some unrelated reason.
+	var netErr net.Error
+	require.True(t, errors.As(err, &netErr) && netErr.Timeout(),
+		"write must fail with a timeout from the write deadline, got: %v", err)
+}
+
+// TestWriteDataFrame_DeadlineDoesNotBreakHealthyWrites pins the other half: the
+// deadline is per-write, so a connection that is being read normally keeps
+// working across many writes. A deadline set once and never refreshed would
+// pass the stalled-peer test above while breaking every long-lived connection
+// after the first expiry -- exactly the regression this guards.
+func TestWriteDataFrame_DeadlineDoesNotBreakHealthyWrites(t *testing.T) {
+	readerDone := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := WebSocketUpgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		defer close(readerDone)
+		for {
+			if _, _, err := conn.ReadMessage(); err != nil {
+				return
+			}
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	client, _, err := websocket.DefaultDialer.Dial("ws"+strings.TrimPrefix(srv.URL, "http"), nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = client.Close() })
+
+	var mu sync.Mutex
+	// A short write wait plus a gap longer than it: if the deadline were set
+	// once instead of per write, the second write would land after expiry and
+	// fail.
+	for i := 0; i < 5; i++ {
+		require.NoError(t,
+			writeDataFrame(client, &mu, websocket.TextMessage, []byte(`{"jsonrpc":"2.0"}`), 50*time.Millisecond),
+			"write %d to a healthy peer must succeed: the deadline must be refreshed per write", i)
+		time.Sleep(60 * time.Millisecond)
+	}
+
+	require.NoError(t, client.Close())
+	select {
+	case <-readerDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for the reader to observe the close")
+	}
+}


### PR DESCRIPTION
Fixes three WebSocket bridge bugs. Two commits, split so the interop fix can be reverted independently of the hardening.

## 1. Frame type destroyed across the bridge (`7740262`)

The bridge hardcoded `websocket.BinaryMessage` on both data-frame writes, discarding the type the client and backend actually sent.

No relay protobuf carries a frame type — not `RelayRequest`, not `RelayResponse` — so the WebSocket envelope is the only channel for it. Hardcoding destroys information nothing downstream can reconstruct.

**Impact:** a browser doing `ws.onmessage = e => JSON.parse(e.data)` gets a Blob instead of a string and throws. `eth_subscribe` from a browser works against poktroll and breaks against this relayer. Text-only JSON-RPC backends may reject the binary frames on the other hop.

**This relayer was the only divergence in the stack.** Verified independently:

| Component | Behaviour |
|---|---|
| poktroll `pkg/relayer/proxy/websockets/bridge.go:313,436` | preserves |
| PATH `websockets/bridge.go:308,347` | preserves |
| SAGE | preserves |
| this bridge's own raw forwarding paths | preserves |
| this bridge's protobuf paths | **hardcoded** |

Each hop now echoes the type it read from that side. Backend frames cannot be paired with client frames — one `eth_subscribe` yields N pushes — so per-hop echo is the only rule that works, which is why poktroll's design is symmetric.

`sendSessionExpirationMessage` still sends BinaryMessage: relayer-initiated on session expiry, so there is no inbound frame to echo.

The CLI client asserted the old behaviour, which is likely why this went unnoticed: client and relayer agreed with each other while both disagreed with the network. Removed rather than relaxed — gorilla's `ReadMessage` only ever returns text or binary, so an accept-either check is dead code.

## 2. Unbounded frame size and write duration (`82bf299`)

Backport of PATH `0f960d95`, which this relayer never had.

**No read limit.** `readLoop` called `ReadMessage()` with no `SetReadLimit`; gorilla's default is unlimited, so one oversized frame is buffered whole and can OOM the process.

On the gateway side this is reachable **pre-auth by anyone**: `CheckOrigin` accepts every origin, `validateAndLogWebSocketHandshake` is permissive by design and never rejects, and `readLoop` allocates the frame *before* `handleGatewayMessage` checks a ring signature. No key, no stake, no session — on the money path. The backend side is bounded too, since a compromised backend can send an abusive frame just as easily.

15MB matches PATH's `maxMessageBytes` and go-ethereum's `wsMessageSizeLimit`, which is what the EVM backends enforce on their own output. Matching the stack is deliberate: a tighter cap would reject frames PATH already accepted and forwarded, reintroducing the cross-component divergence this PR exists to remove.

**No write deadline.** `WriteMessage` does not observe a context. A peer that stops reading blocks the single `messageLoop` goroutine indefinitely — it can never reach its `ctx.Done()` select, so `pingLoop` cancelling the context cannot free it, and since every write is serialised on the same mutex, one stalled peer wedges the whole bridge until the OS TCP timeout. Control writes (ping/close) already passed their own deadline; the five data writes now share `writeDataFrame`.

## Verification

Nothing asserted frame type before, which is how this shipped. Every new test was confirmed to fail on the previous code:

- **Frame type** — text and binary round trips over both hops, so the fix cannot degenerate into hardcoding TextMessage. Fails before: `expected: 1, actual: 2`.
- **Write deadline** — drives a real stalled peer. Removing the deadline **hangs until the go test timeout**, blocked in `writeDataFrame`. That is the bug. A second test asserts the deadline is refreshed per write, catching the wrong fix of setting it once.
- **Read limit** — a real 16MB frame, deliberately unparseable as a `RelayRequest` so it takes the raw `forwardToBackend` path, making "the backend was never hit" the load-bearing assertion. Fails before: the relayer swallowed all 16MB and forwarded it. A 1MB frame is asserted to still be served, so a cap set too low cannot pass unnoticed.

Gates: `go test -tags test -race ./relayer/ ./cmd/...` green; 25–30 repeat runs on the new tests for Rule #1; build, vet, gofmt, lint clean. Commit `7740262` was verified to build and pass `-race` at that commit, so bisect will not land on a broken tree.

## Known gaps, not addressed here

- `msgChan` is buffered at 100, so a bridge can hold ~100 frames in flight — worst case ~1.5GB per connection if `messageLoop` stalls. PATH has the same shape; bounding it has throughput trade-offs.
- The relayer wraps backend payloads in a signed `RelayResponse`, so a backend frame at exactly 15MB exceeds PATH's own 15MB read limit outbound. Narrow (~100 bytes of overhead against 15MB), pre-existing, and stack-wide.