### PR TITLE
fix(relayer): don't fail startup on a disabled simulation block

### DIFF
--- a/client/relay_client/client.go
+++ b/client/relay_client/client.go
@@ -53,6 +53,15 @@ type RelayClient struct {
 	// and reused for all requests within that session.
 	// Thread-safe via sync.Map for concurrent load testing.
 	ringCache sync.Map // map[ringCacheKey]*ring.Ring
+
+	// simRingCache stores rings for the simulated-relay path, keyed by the
+	// pinned pubkeys they are built from (simRingCacheKey). Separate from
+	// ringCache because a pinned ring has no session to scope it: it is
+	// valid for as long as the pubkeys are, so it is built once per identity
+	// and reused for every simulated relay. See simRingFor for why building
+	// it per call is expensive.
+	// Thread-safe via sync.Map for concurrent load testing.
+	simRingCache sync.Map // map[string]*simPinnedRing
 }
 
 // Config contains configuration for the relay client.

--- a/client/relay_client/simulated.go
+++ b/client/relay_client/simulated.go
@@ -4,12 +4,14 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
+	"strings"
 	"time"
 
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
 	cosmostypes "github.com/cosmos/cosmos-sdk/types"
 	servicetypes "github.com/pokt-network/poktroll/x/service/types"
 	sessiontypes "github.com/pokt-network/poktroll/x/session/types"
+	"github.com/pokt-network/ring-go"
 
 	"github.com/pokt-network/pocket-relay-miner/relayer"
 	"github.com/pokt-network/pocket-relay-miner/rings"
@@ -29,6 +31,78 @@ const (
 	simSessionStartHeight = 1
 	simSessionEndHeight   = 2
 )
+
+// simPinnedRing is the per-identity work that is a pure function of the pinned
+// pubkeys: the ring itself, and the application address derived from the app
+// pubkey. Both are identical for every relay built against a given identity.
+type simPinnedRing struct {
+	ring       *ring.Ring
+	appAddress string
+}
+
+// simRingCacheKey builds the cache key for a pinned ring.
+//
+// The separators matter: pubkeys are fixed-width hex here, but the key must not
+// depend on that. Without a delimiter between the app key and the gateway list,
+// {app: a, gateways: [b, c]} and {app: a+b, gateways: [c]} would collide and
+// hand back a ring whose members are not the ones asked for — relays signed
+// against the wrong ring, rejected by the relayer with no useful error.
+func simRingCacheKey(appPubKeyHex string, gatewayPubKeysHex []string) string {
+	return appPubKeyHex + "|" + strings.Join(gatewayPubKeysHex, ",")
+}
+
+// simRingFor returns the ring and app address for a set of pinned pubkeys,
+// building them on first use and reusing them afterwards.
+//
+// Building is expensive and repeated: rings.PubKeyFromHex decompresses each key
+// to a curve point to validate it (~48us/key) and discards the point, and
+// rings.GetRingFromPubKeys then decompresses the very same keys again. The CLI
+// load generator calls BuildSimulatedRelayRequest once per request with the
+// same pinned pubkeys every time, so without this cache a `--simulate` load
+// test burns that cost N times and under-reports the relayer's throughput by
+// measuring its own client.
+//
+// Failures are deliberately not cached: a malformed pubkey must name its field
+// on every call, and a cached error is indistinguishable from a cached success
+// at the call site.
+func (c *RelayClient) simRingFor(appPubKeyHex string, gatewayPubKeysHex []string) (*simPinnedRing, error) {
+	key := simRingCacheKey(appPubKeyHex, gatewayPubKeysHex)
+	if cached, ok := c.simRingCache.Load(key); ok {
+		return cached.(*simPinnedRing), nil
+	}
+
+	appPub, err := rings.PubKeyFromHex(appPubKeyHex)
+	if err != nil {
+		return nil, fmt.Errorf("app pubkey: %w", err)
+	}
+	if len(gatewayPubKeysHex) == 0 {
+		return nil, fmt.Errorf("at least one gateway pubkey is required")
+	}
+
+	ringPubKeys := make([]cryptotypes.PubKey, 0, 1+len(gatewayPubKeysHex))
+	ringPubKeys = append(ringPubKeys, appPub)
+	for i, gwHex := range gatewayPubKeysHex {
+		gwPub, err := rings.PubKeyFromHex(gwHex)
+		if err != nil {
+			return nil, fmt.Errorf("gateway pubkey[%d]: %w", i, err)
+		}
+		ringPubKeys = append(ringPubKeys, gwPub)
+	}
+
+	appRing, err := rings.GetRingFromPubKeys(ringPubKeys)
+	if err != nil {
+		return nil, fmt.Errorf("build ring: %w", err)
+	}
+
+	built := &simPinnedRing{
+		ring:       appRing,
+		appAddress: cosmostypes.AccAddress(appPub.Address()).String(),
+	}
+	// LoadOrStore, not Store: concurrent first-touch of the same key must leave
+	// every caller holding the SAME ring, not one ring each.
+	actual, _ := c.simRingCache.LoadOrStore(key, built)
+	return actual.(*simPinnedRing), nil
+}
 
 // BuildSimulatedRelayRequest builds a real, ring-signed RelayRequest for the
 // relayer's simulated-relay path: a synthetic session carrying a fresh
@@ -67,27 +141,9 @@ func (c *RelayClient) BuildSimulatedRelayRequest(
 	payload []byte,
 	now time.Time,
 ) (*servicetypes.RelayRequest, []byte, error) {
-	appPub, err := rings.PubKeyFromHex(appPubKeyHex)
+	pinned, err := c.simRingFor(appPubKeyHex, gatewayPubKeysHex)
 	if err != nil {
-		return nil, nil, fmt.Errorf("app pubkey: %w", err)
-	}
-	if len(gatewayPubKeysHex) == 0 {
-		return nil, nil, fmt.Errorf("at least one gateway pubkey is required")
-	}
-
-	ringPubKeys := make([]cryptotypes.PubKey, 0, 1+len(gatewayPubKeysHex))
-	ringPubKeys = append(ringPubKeys, appPub)
-	for i, gwHex := range gatewayPubKeysHex {
-		gwPub, err := rings.PubKeyFromHex(gwHex)
-		if err != nil {
-			return nil, nil, fmt.Errorf("gateway pubkey[%d]: %w", i, err)
-		}
-		ringPubKeys = append(ringPubKeys, gwPub)
-	}
-
-	appRing, err := rings.GetRingFromPubKeys(ringPubKeys)
-	if err != nil {
-		return nil, nil, fmt.Errorf("build ring: %w", err)
+		return nil, nil, err
 	}
 
 	nonceHex, err := randomSimNonceHex()
@@ -99,7 +155,7 @@ func (c *RelayClient) BuildSimulatedRelayRequest(
 		Payload: payload,
 		Meta: servicetypes.RelayRequestMetadata{
 			SessionHeader: &sessiontypes.SessionHeader{
-				ApplicationAddress:      cosmostypes.AccAddress(appPub.Address()).String(),
+				ApplicationAddress:      pinned.appAddress,
 				ServiceId:               serviceID,
 				SessionId:               relayer.FormatSimSessionID(now, nonceHex),
 				SessionStartBlockHeight: simSessionStartHeight,
@@ -110,7 +166,7 @@ func (c *RelayClient) BuildSimulatedRelayRequest(
 		},
 	}
 
-	if err := c.signer.SignRelayRequestWithRing(relayRequest, appRing); err != nil {
+	if err := c.signer.SignRelayRequestWithRing(relayRequest, pinned.ring); err != nil {
 		return nil, nil, fmt.Errorf("sign simulated relay request: %w", err)
 	}
 

--- a/client/relay_client/simulated_test.go
+++ b/client/relay_client/simulated_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -32,20 +33,20 @@ const simCLITestServiceID = "svc-test"
 // in modern grpc-go, so this never performs a network call — matching
 // production, where BuildSimulatedRelayRequest is the only method exercised
 // here and never touches queryClients.
-func newSimTestRelayClient(t *testing.T, appPrivHex, gwPrivHex string) *RelayClient {
-	t.Helper()
+func newSimTestRelayClient(tb testing.TB, appPrivHex, gwPrivHex string) *RelayClient {
+	tb.Helper()
 	logger := logging.NewLoggerFromConfig(logging.DefaultConfig())
 
 	qc, err := query.NewQueryClients(logger, query.ClientConfig{GRPCEndpoint: "127.0.0.1:1"})
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = qc.Close() })
+	require.NoError(tb, err)
+	tb.Cleanup(func() { _ = qc.Close() })
 
 	rc, err := NewRelayClient(Config{
 		AppPrivateKeyHex:     appPrivHex,
 		GatewayPrivateKeyHex: gwPrivHex,
 		QueryClients:         qc,
 	}, logger)
-	require.NoError(t, err)
+	require.NoError(tb, err)
 	return rc
 }
 
@@ -248,4 +249,171 @@ func TestBuildSimulatedRelayRequest_MultiGatewayRing(t *testing.T) {
 	)
 	require.NoError(t, err)
 	require.NoError(t, rr.ValidateBasic())
+}
+
+// --- pinned simulation ring cache ---
+
+// The pinned ring is a pure function of the pubkeys it is built from, and the
+// CLI load generator passes the SAME pubkeys on every one of its N requests.
+// Rebuilding it per call re-runs secp256k1 point decompression for every ring
+// member twice (once in rings.PubKeyFromHex's curve check, once in
+// rings.GetRingFromPubKeys), which at ~48us per key dominates the builder.
+// The ring must therefore be built once and reused.
+func TestSimRingCache_ReusesRingAcrossCalls(t *testing.T) {
+	keys := newSimTestKeys()
+	rc := newSimTestRelayClient(t, keys.appPrivHex, keys.gwPrivHex)
+
+	first, err := rc.simRingFor(keys.appPubHex, []string{keys.gwPubHex})
+	require.NoError(t, err)
+	second, err := rc.simRingFor(keys.appPubHex, []string{keys.gwPubHex})
+	require.NoError(t, err)
+
+	require.Same(t, first, second, "the same pinned pubkeys must yield the cached ring, not a rebuilt one")
+}
+
+// Distinct pinned rings must not collide: a second identity has to get its own
+// ring and its own app address, or relays would be signed against the wrong
+// ring and rejected.
+func TestSimRingCache_DistinctKeysGetDistinctEntries(t *testing.T) {
+	keys := newSimTestKeys()
+	rc := newSimTestRelayClient(t, keys.appPrivHex, keys.gwPrivHex)
+	otherGwPubHex := hex.EncodeToString(secp256k1.GenPrivKey().PubKey().Bytes())
+
+	one, err := rc.simRingFor(keys.appPubHex, []string{keys.gwPubHex})
+	require.NoError(t, err)
+	two, err := rc.simRingFor(keys.appPubHex, []string{otherGwPubHex})
+	require.NoError(t, err)
+
+	require.NotSame(t, one, two, "different gateway sets must not share a cache entry")
+	require.Equal(t, one.appAddress, two.appAddress, "same app pubkey must derive the same app address")
+
+	three, err := rc.simRingFor(otherGwPubHex, []string{keys.gwPubHex})
+	require.NoError(t, err)
+	require.NotEqual(t, one.appAddress, three.appAddress, "a different app pubkey must derive a different address")
+}
+
+// The cache key must not let a different (app, gateways) split collide by
+// concatenation — the classic delimiter bug, where {a, [b,c]} and {a+b, [c]}
+// hash to the same string.
+func TestSimRingCache_KeyIsUnambiguous(t *testing.T) {
+	a := hex.EncodeToString(secp256k1.GenPrivKey().PubKey().Bytes())
+	b := hex.EncodeToString(secp256k1.GenPrivKey().PubKey().Bytes())
+	c := hex.EncodeToString(secp256k1.GenPrivKey().PubKey().Bytes())
+
+	require.NotEqual(t,
+		simRingCacheKey(a, []string{b, c}),
+		simRingCacheKey(a+b, []string{c}),
+		"the cache key must not be ambiguous across the app/gateway boundary")
+	require.NotEqual(t,
+		simRingCacheKey(a, []string{b, c}),
+		simRingCacheKey(a, []string{b + c}),
+		"the cache key must not be ambiguous across the gateway separator")
+}
+
+// A malformed pubkey must keep failing on every call: caching a failure would
+// be indistinguishable from caching a success at the call site, and the error
+// must name the field every time.
+func TestSimRingCache_DoesNotCacheFailures(t *testing.T) {
+	keys := newSimTestKeys()
+	rc := newSimTestRelayClient(t, keys.appPrivHex, keys.gwPrivHex)
+
+	for i := 0; i < 3; i++ {
+		_, err := rc.simRingFor("not-hex", []string{keys.gwPubHex})
+		require.Error(t, err, "call %d must fail", i)
+		require.Contains(t, err.Error(), "app pubkey")
+	}
+
+	// A valid build after failures still works (the failures poisoned nothing).
+	got, err := rc.simRingFor(keys.appPubHex, []string{keys.gwPubHex})
+	require.NoError(t, err)
+	require.NotNil(t, got)
+}
+
+// The load generator drives this from many goroutines at once (-c 200), so the
+// cache must be safe under concurrent first-touch of the same key.
+func TestSimRingCache_ConcurrentAccess(t *testing.T) {
+	keys := newSimTestKeys()
+	rc := newSimTestRelayClient(t, keys.appPrivHex, keys.gwPrivHex)
+
+	const goroutines = 32
+	results := make(chan *simPinnedRing, goroutines)
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			got, err := rc.simRingFor(keys.appPubHex, []string{keys.gwPubHex})
+			require.NoError(t, err)
+			results <- got
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(results)
+
+	first := <-results
+	require.NotNil(t, first)
+	for got := range results {
+		require.Same(t, first, got, "every goroutine must observe the same cached ring")
+	}
+}
+
+// End-to-end: caching the ring must not freeze anything that has to stay
+// per-request. Two successive builds share an app address but must carry
+// distinct session ids (fresh nonce) and distinct signatures, or the relayer
+// would reject the second as a replay.
+func TestBuildSimulatedRelayRequest_CachedRingKeepsPerRequestFieldsFresh(t *testing.T) {
+	keys := newSimTestKeys()
+	rc := newSimTestRelayClient(t, keys.appPrivHex, keys.gwPrivHex)
+	now := time.Unix(1700000000, 0).UTC()
+
+	first, _, err := rc.BuildSimulatedRelayRequest(
+		keys.appPubHex, []string{keys.gwPubHex}, simCLITestServiceID, keys.supplierAddr, []byte(`{"a":1}`), now,
+	)
+	require.NoError(t, err)
+	second, _, err := rc.BuildSimulatedRelayRequest(
+		keys.appPubHex, []string{keys.gwPubHex}, simCLITestServiceID, keys.supplierAddr, []byte(`{"a":1}`), now,
+	)
+	require.NoError(t, err)
+
+	require.Equal(t,
+		first.GetMeta().SessionHeader.ApplicationAddress,
+		second.GetMeta().SessionHeader.ApplicationAddress,
+		"the app address is derived from the pinned key and must be stable")
+	require.NotEqual(t,
+		first.GetMeta().SessionHeader.SessionId,
+		second.GetMeta().SessionHeader.SessionId,
+		"each call must draw a fresh nonce; a cached ring must not freeze the session id")
+	require.NotEqual(t, first.GetMeta().Signature, second.GetMeta().Signature,
+		"each call must produce a distinct signature, or the relayer dedups the second as a replay")
+	require.NoError(t, first.ValidateBasic())
+	require.NoError(t, second.ValidateBasic())
+}
+
+// BenchmarkBuildSimulatedRelayRequest guards the pinned-ring cache. This is the
+// CLI load generator's per-request path: `relay <transport> --simulate -n N`
+// builds one of these per request, so its cost is subtracted from the RPS the
+// operator reads off the run. Rebuilding the ring per call (decompressing every
+// ring member to a curve point twice, at ~48us/key) measured ~1.35ms/op and 180
+// allocs; reusing it measures ~1.16ms/op and 111 allocs on the same machine.
+//
+// A regression here does not break correctness — it makes a --simulate load
+// test silently under-report the relayer by measuring its own client.
+func BenchmarkBuildSimulatedRelayRequest(b *testing.B) {
+	keys := newSimTestKeys()
+	rc := newSimTestRelayClient(b, keys.appPrivHex, keys.gwPrivHex)
+	now := time.Unix(1700000000, 0).UTC()
+	payload := []byte(`{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}`)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, _, err := rc.BuildSimulatedRelayRequest(
+			keys.appPubHex, []string{keys.gwPubHex}, simCLITestServiceID, keys.supplierAddr, payload, now,
+		); err != nil {
+			b.Fatal(err)
+		}
+	}
 }

--- a/cmd/cmd_relayer.go
+++ b/cmd/cmd_relayer.go
@@ -140,6 +140,22 @@ Examples:
 			}
 			fmt.Printf("config OK: %s would start\n", configPath)
 
+			// A disabled simulation block is skipped by Validate, by design.
+			// Report what enabling it would do anyway: otherwise the operator
+			// finds out on the deploy that flips the switch, when the relayer
+			// refuses to boot and stops serving real traffic. Advisory only —
+			// exit status stays 0.
+			//
+			// Only when identities are actually pinned: the shipped default is
+			// disabled with none, and warning about that would fire on every
+			// correct config.
+			if !config.Simulation.Enabled && len(config.Simulation.Identities) > 0 {
+				if simErr := config.Simulation.ValidateAsIfEnabled(); simErr != nil {
+					fmt.Printf("warning: simulation is disabled, so its config was not checked; "+
+						"it would be REJECTED if you set simulation.enabled: true: %v\n", simErr)
+				}
+			}
+
 			checkStake, _ := cmd.Flags().GetBool(flagCheckStake)
 			if !checkStake {
 				return nil
@@ -762,6 +778,18 @@ func runHARelayer(cmd *cobra.Command, _ []string) error {
 				logger.Info().
 					Int("identities", len(config.Simulation.Identities)).
 					Msg("simulated relays ENABLED")
+			} else if len(config.Simulation.Identities) > 0 {
+				// The block is off, so it cannot affect this process — but it
+				// may still be unbootable, and the next deploy that enables it
+				// would crashloop this replica. Say so now, while it is cheap.
+				// Identities must be present: the shipped default is disabled
+				// with none, and warning about that would fire on every
+				// correct config.
+				if simCfgErr := config.Simulation.ValidateAsIfEnabled(); simCfgErr != nil {
+					logger.Warn().
+						Err(simCfgErr).
+						Msg("simulation is disabled and its config is invalid: enabling it would prevent startup")
+				}
 			}
 
 			logger.Info().

--- a/cmd/cmd_relayer.go
+++ b/cmd/cmd_relayer.go
@@ -156,6 +156,17 @@ Examples:
 				}
 			}
 
+			// An expired identity is valid config that serves nothing. Report
+			// it here rather than let a health-check pipeline go quiet with no
+			// explanation. Advisory by design — see ExpiredIdentities. Not
+			// gated on simulation.enabled: this command is a look-ahead, and
+			// an identity that is already dead is worth knowing about before
+			// the deploy that switches the feature on, not after.
+			if expired := config.Simulation.ExpiredIdentities(time.Now()); len(expired) > 0 {
+				fmt.Printf("warning: simulation identities are past their not_after and will reject every relay: %s\n",
+					strings.Join(expired, ", "))
+			}
+
 			checkStake, _ := cmd.Flags().GetBool(flagCheckStake)
 			if !checkStake {
 				return nil
@@ -778,6 +789,14 @@ func runHARelayer(cmd *cobra.Command, _ []string) error {
 				logger.Info().
 					Int("identities", len(config.Simulation.Identities)).
 					Msg("simulated relays ENABLED")
+				// Valid config that serves nothing: the identity loads and
+				// then rejects every relay with ErrSimExpired. Never fatal —
+				// see SimulationConfig.ExpiredIdentities.
+				if expired := config.Simulation.ExpiredIdentities(time.Now()); len(expired) > 0 {
+					logger.Warn().
+						Strs("key_ids", expired).
+						Msg("simulated relay identities are past their not_after: they will reject every relay")
+				}
 			} else if len(config.Simulation.Identities) > 0 {
 				// The block is off, so it cannot affect this process — but it
 				// may still be unbootable, and the next deploy that enables it

--- a/config.relayer.example.yaml
+++ b/config.relayer.example.yaml
@@ -385,29 +385,35 @@ simulation:
   freshness_window_seconds: 30
 
   # Pinned simulated-relay identities. Each identity is served ONLY when
-  # its own `enabled: true` is set explicitly (fail-closed) - defaults do
-  # not turn identities on.
-  identities:
-    - key_id: "example-sim-identity"
-      enabled: true
-
-      # Optional RFC3339 expiry; omit for no expiry.
-      # not_after: "2027-01-01T00:00:00Z"
-
-      # Per-identity simulated relay rate. Default: 5.
-      max_rps: 5
-
-      # Compressed secp256k1 pubkey (hex) of the simulated application.
-      # EXAMPLE VALUE ONLY - replace with a real pinned key, never reuse
-      # this placeholder-looking value in a real deployment.
-      app_pubkey_hex: "02aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-
-      # Compressed secp256k1 pubkeys (hex) of the simulated gateway ring
-      # members. At least one required. EXAMPLE VALUES ONLY.
-      gateway_pubkeys_hex:
-        - "03bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
-
-      # Restrict this identity to specific services. Empty/omitted means
-      # all configured services are allowed.
-      # allowed_services:
-      #   - develop-http
+  # BOTH `simulation.enabled: true` above AND its own `enabled: true` are
+  # set explicitly (fail-closed) - defaults do not turn identities on.
+  #
+  # Left empty on purpose. The keys below are illustrative and are NOT
+  # valid secp256k1 public keys - a config carrying them is rejected at
+  # startup once `simulation.enabled` is true. Generate your own dedicated
+  # simulation app and gateway key pairs and pin their public halves here;
+  # see docs/simulated-relays.md for the provisioning steps.
+  identities: []
+  #  - key_id: "my-sim-identity"        # sent as the Pocket-Simulation-Key-Id header
+  #    enabled: true                    # per-identity switch (required to activate)
+  #
+  #    # Optional RFC3339 expiry; omit for no expiry.
+  #    not_after: "2027-01-01T00:00:00Z"
+  #
+  #    # Per-identity simulated relay rate. Default: 5.
+  #    max_rps: 5
+  #
+  #    # Compressed secp256k1 pubkey (hex, 33 bytes) of the simulated
+  #    # application. Must be a real public key you generated.
+  #    app_pubkey_hex: "02<64 hex chars>"
+  #
+  #    # Compressed secp256k1 pubkeys (hex) of the simulated gateway ring
+  #    # members. At least one required. Keep their private halves in your
+  #    # health-check tooling - never in this file.
+  #    gateway_pubkeys_hex:
+  #      - "03<64 hex chars>"
+  #
+  #    # Restrict this identity to specific services. Empty/omitted means
+  #    # all configured services are allowed.
+  #    allowed_services:
+  #      - develop-http

--- a/config.relayer.example.yaml
+++ b/config.relayer.example.yaml
@@ -388,32 +388,42 @@ simulation:
   # BOTH `simulation.enabled: true` above AND its own `enabled: true` are
   # set explicitly (fail-closed) - defaults do not turn identities on.
   #
-  # Left empty on purpose. The keys below are illustrative and are NOT
-  # valid secp256k1 public keys - a config carrying them is rejected at
-  # startup once `simulation.enabled` is true. Generate your own dedicated
-  # simulation app and gateway key pairs and pin their public halves here;
-  # see docs/simulated-relays.md for the provisioning steps.
-  identities: []
-  #  - key_id: "my-sim-identity"        # sent as the Pocket-Simulation-Key-Id header
-  #    enabled: true                    # per-identity switch (required to activate)
+  # No identities are pinned: the whole `identities` key is commented out
+  # below, so the shipped example needs no edit to stay inert. The keys in
+  # the template are illustrative and are NOT valid secp256k1 public keys -
+  # a config carrying them is rejected at startup once `simulation.enabled`
+  # is true. Generate your own dedicated simulation app and gateway key
+  # pairs and pin their public halves here; see docs/simulated-relays.md
+  # for the provisioning steps.
   #
-  #    # Optional RFC3339 expiry; omit for no expiry.
-  #    not_after: "2027-01-01T00:00:00Z"
+  # TO PIN AN IDENTITY: delete the leading "# " (hash and one space) from
+  # every line of the template below, then replace the placeholder keys.
+  # Lines that are still comments after that single pass carry a second
+  # "#" on purpose: they are OPTIONAL fields, and leaving them commented is
+  # what keeps them unset. Uncomment only the ones you actually want.
+  # identities:
+  #   - key_id: "my-sim-identity"      # sent as the Pocket-Simulation-Key-Id header
+  #     enabled: true                  # per-identity switch (required to activate)
   #
-  #    # Per-identity simulated relay rate. Default: 5.
-  #    max_rps: 5
+  #     # Compressed secp256k1 pubkey (hex, 33 bytes) of the simulated
+  #     # application. Must be a real public key you generated.
+  #     app_pubkey_hex: "02<64 hex chars>"
   #
-  #    # Compressed secp256k1 pubkey (hex, 33 bytes) of the simulated
-  #    # application. Must be a real public key you generated.
-  #    app_pubkey_hex: "02<64 hex chars>"
+  #     # Compressed secp256k1 pubkeys (hex) of the simulated gateway ring
+  #     # members. At least one required. Keep their private halves in your
+  #     # health-check tooling - never in this file.
+  #     gateway_pubkeys_hex:
+  #       - "03<64 hex chars>"
   #
-  #    # Compressed secp256k1 pubkeys (hex) of the simulated gateway ring
-  #    # members. At least one required. Keep their private halves in your
-  #    # health-check tooling - never in this file.
-  #    gateway_pubkeys_hex:
-  #      - "03<64 hex chars>"
+  #     ## OPTIONAL - per-identity simulated relay rate. Default: 5.
+  #     # max_rps: 5
   #
-  #    # Restrict this identity to specific services. Empty/omitted means
-  #    # all configured services are allowed.
-  #    allowed_services:
-  #      - develop-http
+  #     ## OPTIONAL - RFC3339 expiry, for key rotation. Unset means the
+  #     ## identity never expires. Setting this is a scheduled outage of
+  #     ## your simulated traffic on that date - pick it deliberately.
+  #     # not_after: "2027-01-01T00:00:00Z"
+  #
+  #     ## OPTIONAL - restrict this identity to specific services. Unset
+  #     ## means every configured service is allowed.
+  #     # allowed_services:
+  #     #   - develop-http

--- a/config.relayer.schema.yaml
+++ b/config.relayer.schema.yaml
@@ -580,7 +580,11 @@ properties:
         minimum: 1
       identities:
         type: array
-        description: Pinned simulated-relay identities
+        description: >-
+          Pinned simulated-relay identities. May be empty (or omitted)
+          only while enabled is false; enabling the feature with nothing
+          pinned is rejected at load, since it would boot cleanly and then
+          reject every simulated relay as an unknown key_id.
         items:
           type: object
           required:

--- a/docs/simulated-relays.md
+++ b/docs/simulated-relays.md
@@ -129,7 +129,10 @@ simulation.identities[0] (key_id=my-sim-identity): gateway_pubkeys_hex[0]: simul
 ```
 
 Validation runs only when `simulation.enabled` is `true`; a disabled block is
-skipped wholesale.
+skipped wholesale. Turning the feature on with no identities pinned is itself
+rejected — an enabled block that serves nothing would reject every simulated
+relay as an unknown `key_id`, which looks identical to a forged signature in
+the metrics.
 
 Provisioning an identity:
 
@@ -143,9 +146,18 @@ Provisioning an identity:
    identity.
 3. Pick a `key_id` and set `enabled: true`.
 
-`config.relayer.example.yaml` ships this block with `enabled: false` and an
-empty `identities: []`, with the field shape shown in comments. Uncomment and
-fill it in with your own keys rather than editing placeholder values in place.
+`config.relayer.example.yaml` ships this block with `enabled: false` and the
+whole `identities` key commented out, with the field shape shown as a template.
+To pin an identity, delete the leading `# ` (hash and one space) from every line
+of that template and replace the placeholder keys — do not edit placeholder
+values in place.
+
+Lines that are still comments after that single pass carry a second `#` on
+purpose: those are the optional fields (`max_rps`, `not_after`,
+`allowed_services`), and leaving them commented is what keeps them unset.
+Uncomment only the ones you want. In particular, `not_after` is a scheduled
+stop: on that date the identity stops being served and your simulated traffic
+goes dark, with no other config change and no prior warning.
 
 ### The header
 

--- a/docs/simulated-relays.md
+++ b/docs/simulated-relays.md
@@ -71,7 +71,9 @@ clock, shared Redis). Nothing depends on the honesty of the caller.
 
 - **Off by default.** `simulation.enabled` defaults to `false`. When off, the
   simulation header is **ignored** (a stray header never turns a real relay
-  into an error).
+  into an error), and the `identities` list is neither validated nor loaded —
+  a leftover or half-filled simulation block cannot affect a relayer that has
+  the feature switched off.
 - **Config allowlist.** Only pinned, enabled, unexpired identities are
   accepted, selected by a `key_id`.
 - **Real ring signature over an operator-controlled ring.** The caller must
@@ -117,7 +119,17 @@ simulation:
 
 Config validation **rejects** a config that pins the ring-padding placeholder
 key, a duplicate `key_id`, a malformed pubkey, or an identity with no gateway
-pubkeys.
+pubkeys. "Malformed" includes a pubkey that is the right length and has a valid
+`02`/`03` compressed prefix but whose x coordinate is **not a point on the
+secp256k1 curve** — the shape you get from pasting a documentation placeholder
+into a real config. The rejection names the identity and the field, e.g.:
+
+```
+simulation.identities[0] (key_id=my-sim-identity): gateway_pubkeys_hex[0]: simulation identity: malformed pubkey hex: pubkey is not a valid secp256k1 curve point: invalid public key: x coordinate bbbb...bbbb is not on the secp256k1 curve
+```
+
+Validation runs only when `simulation.enabled` is `true`; a disabled block is
+skipped wholesale.
 
 Provisioning an identity:
 
@@ -125,8 +137,15 @@ Provisioning an identity:
    keypair for simulation. Keep the private keys in your health-check / operator
    tooling — they never go in the relayer config.
 2. Put the two **public** keys (hex, compressed secp256k1) in `app_pubkey_hex`
-   and `gateway_pubkeys_hex`.
+   and `gateway_pubkeys_hex`. These must be public halves of key pairs you
+   actually generated — the relayer verifies a real ring signature against
+   them, so invented or copied-from-docs values can never produce a servable
+   identity.
 3. Pick a `key_id` and set `enabled: true`.
+
+`config.relayer.example.yaml` ships this block with `enabled: false` and an
+empty `identities: []`, with the field shape shown in comments. Uncomment and
+fill it in with your own keys rather than editing placeholder values in place.
 
 ### The header
 

--- a/docs/simulated-relays.md
+++ b/docs/simulated-relays.md
@@ -157,7 +157,22 @@ purpose: those are the optional fields (`max_rps`, `not_after`,
 `allowed_services`), and leaving them commented is what keeps them unset.
 Uncomment only the ones you want. In particular, `not_after` is a scheduled
 stop: on that date the identity stops being served and your simulated traffic
-goes dark, with no other config change and no prior warning.
+goes dark, with no other config change.
+
+An identity whose `not_after` has already passed is **not** a startup error —
+it loads, and then rejects every relay aimed at it with `simulation: identity
+expired (not_after)`. Making it fatal would mean the next restart of a healthy
+relayer refuses to boot and takes real, paid traffic down over a dead
+simulation identity. Instead, both `relayer validate` and relayer startup warn
+and name the `key_id`:
+
+```
+warning: simulation identities are past their not_after and will reject every relay: igniter-healthcheck
+```
+
+`relayer validate` reports this whether or not `simulation.enabled` is set — a
+dead identity is worth knowing about *before* the deploy that switches the
+feature on.
 
 ### The header
 

--- a/docs/simulated-relays.md
+++ b/docs/simulated-relays.md
@@ -263,13 +263,24 @@ you should check them on your own deployment before wiring simulated relays into
 anything. The walk-through below is the one used to validate the feature; every
 command and every expected result is real output from a localnet run.
 
-> **Localnet setup gotcha.** `tilt_config.yaml` is user-local and gitignored, and
-> it **wins** over the config Tilt generates. The localnet simulation identities
-> are injected on the *generation* path, so a `tilt_config.yaml` created before
-> simulation existed has no `simulation:` block and every command below will fail
-> with a confusing `403`. If that happens, delete the file and let Tilt rebuild
-> it: `rm tilt_config.yaml && tilt up`. Confirm with
-> `grep -A2 'simulation:' tilt_config.yaml`.
+> **Where the localnet identities come from.** `tilt_config.yaml` is user-local
+> and gitignored. If its `simulation` block has an `identities` key, that key
+> **wins** — it is the file to edit to change an identity's `not_after`,
+> `max_rps` or `allowed_services` for a localnet experiment. If the key is absent
+> (including a file with no `simulation` block at all, e.g. one created before the
+> feature existed), Tilt injects the five `sim-*` localnet defaults listed above,
+> so the commands here work either way. An explicit `identities: []` is respected
+> rather than filled in, so you can reproduce the "enabled but nothing pinned"
+> config error on purpose. Inspect what you ended up with:
+> `kubectl get cm relayer-config -o jsonpath='{.data.config\.yaml}' | grep -A20 'simulation:'`
+>
+> Editing the config **rolls the relayer and miner pods**: their Deployments carry
+> a `pocket-relay-miner/config-hash` annotation over the rendered config. This is
+> load-bearing, not cosmetic — a mounted ConfigMap change does not restart pods on
+> its own, and neither binary re-reads its config after startup (simulation
+> identities in particular are not hot-reloaded), so without the annotation a
+> config edit would update the ConfigMap and leave the running pods on the old
+> config, with no error and no signal.
 
 #### 1. Baseline: is the relayer serving real relays?
 

--- a/relayer/simulation.go
+++ b/relayer/simulation.go
@@ -236,8 +236,16 @@ func NewSimulationVerifier(
 //
 // When the feature is disabled the identity list is skipped entirely, matching
 // SimulationConfig.Validate's contract that a disabled block never blocks
-// startup regardless of what it contains. Nothing reads the map while
-// disabled: every serving path is gated on Enabled().
+// startup regardless of what it contains.
+//
+// The empty map is the fail-closed value, not merely an unread one. HTTP and
+// gRPC check Enabled() per request, so they never reach it. WebSocket does
+// NOT: it evaluates Enabled() once at handshake and then calls Verify per
+// message for the life of the connection, so a Reload that switches the
+// feature off makes an already-simulated bridge read this map and close the
+// connection on ErrSimUnknownKeyID. That is the correct outcome — a
+// disabled feature must stop serving — but it is a rejection, not a graceful
+// teardown, so do not "optimise" this into reusing the previous identities.
 func buildSimIdentities(cfg *SimulationConfig, clock func() time.Time) (map[string]*simIdentity, error) {
 	if !cfg.Enabled {
 		return map[string]*simIdentity{}, nil

--- a/relayer/simulation.go
+++ b/relayer/simulation.go
@@ -233,7 +233,16 @@ func NewSimulationVerifier(
 // config must already have passed SimulationConfig.Validate (placeholder
 // rejected, pubkeys parse), so parse errors here are unexpected but still
 // surfaced.
+//
+// When the feature is disabled the identity list is skipped entirely, matching
+// SimulationConfig.Validate's contract that a disabled block never blocks
+// startup regardless of what it contains. Nothing reads the map while
+// disabled: every serving path is gated on Enabled().
 func buildSimIdentities(cfg *SimulationConfig, clock func() time.Time) (map[string]*simIdentity, error) {
+	if !cfg.Enabled {
+		return map[string]*simIdentity{}, nil
+	}
+
 	out := make(map[string]*simIdentity, len(cfg.Identities))
 	for _, idc := range cfg.Identities {
 		appPub, err := rings.PubKeyFromHex(idc.AppPubKeyHex)

--- a/relayer/simulation_config.go
+++ b/relayer/simulation_config.go
@@ -128,6 +128,40 @@ type SimulationConfig struct {
 	Identities []SimIdentity `yaml:"identities"`
 }
 
+// ExpiredIdentities returns the key_ids of enabled identities whose not_after
+// has already passed at now, in config order. It is the advisory counterpart
+// to Validate: such an identity loads and serves nothing, rejecting every
+// relay aimed at it with ErrSimExpired.
+//
+// This is deliberately NOT part of Validate, and must never become part of it.
+// not_after passes on a wall-clock date nobody redeploys for, so a hard
+// failure would mean the next restart of a healthy relayer — a node reboot, a
+// rescheduled pod — refuses to boot and takes real, paid relay traffic down
+// over a dead simulation identity. The identity going quiet is the intended
+// behaviour of an expiry; the relayer going quiet is not.
+//
+// The boundary matches SimulationVerifier.Verify exactly (now strictly after
+// not_after): an advisory that disagrees with the code that does the rejecting
+// is worse than none. Identities with an unset or unparseable not_after are
+// skipped — an unset one never expires, and a malformed one is Validate's
+// rejection to make.
+func (c *SimulationConfig) ExpiredIdentities(now time.Time) []string {
+	var expired []string
+	for _, id := range c.Identities {
+		if !id.Enabled || id.NotAfter == "" {
+			continue
+		}
+		notAfter, err := time.Parse(time.RFC3339, id.NotAfter)
+		if err != nil {
+			continue
+		}
+		if now.After(notAfter) {
+			expired = append(expired, id.KeyID)
+		}
+	}
+	return expired
+}
+
 // ApplyDefaults fills in zero-value fields with their defaults. It is
 // idempotent (only touches fields still at their zero value) and safe to
 // call multiple times, e.g. once in DefaultConfig() and again after YAML

--- a/relayer/simulation_config.go
+++ b/relayer/simulation_config.go
@@ -28,6 +28,13 @@ const (
 // validation failure has its own sentinel so callers (and tests) can assert
 // the exact failure with errors.Is, rather than matching on error strings.
 var (
+	// ErrSimNoIdentities is returned when the feature is enabled but no
+	// identities are pinned. Such a config boots cleanly and then rejects
+	// every simulated relay as an unknown key_id, which is indistinguishable
+	// at the metrics layer from a forged signature — so the empty list is
+	// named here, at the config field that caused it, instead.
+	ErrSimNoIdentities = errors.New("simulation: enabled but no identities are pinned")
+
 	// ErrSimEmptyKeyID is returned when an identity has no key_id set.
 	ErrSimEmptyKeyID = errors.New("simulation identity: key_id is required")
 
@@ -156,6 +163,29 @@ func (c *SimulationConfig) ApplyDefaults() {
 func (c *SimulationConfig) Validate() error {
 	if !c.Enabled {
 		return nil
+	}
+	return c.ValidateAsIfEnabled()
+}
+
+// ValidateAsIfEnabled runs the identity checks unconditionally: it answers
+// "would this config be rejected if the feature were switched on?" for a
+// block that is currently off.
+//
+// Validate deliberately skips a disabled block, which means a typo in an
+// unused identity survives every deploy and only surfaces the day someone
+// flips enabled: true — at which point the relayer refuses to boot and stops
+// serving real, paid traffic. Callers that can afford to look ahead (config
+// validation tooling, startup logging) use this to warn while the mistake is
+// still cheap. It is advisory: it must never be promoted into a hard failure
+// for a disabled block, since that would break the contract that a disabled
+// block never blocks startup regardless of what it contains.
+func (c *SimulationConfig) ValidateAsIfEnabled() error {
+	// Serving with nothing pinned is always an operator mistake: the feature
+	// was switched on because something was meant to be served, and every
+	// simulated relay would instead be rejected as an unknown key_id. Fail
+	// here rather than at the first health-check relay.
+	if len(c.Identities) == 0 {
+		return fmt.Errorf("simulation.identities: %w", ErrSimNoIdentities)
 	}
 
 	seenKeyIDs := make(map[string]struct{}, len(c.Identities))

--- a/relayer/simulation_config_test.go
+++ b/relayer/simulation_config_test.go
@@ -6,6 +6,8 @@ import (
 	"encoding/hex"
 	"errors"
 	"os"
+	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
@@ -525,6 +527,172 @@ func TestExampleConfig_SimulationBlockStartsCleanly(t *testing.T) {
 	require.NoError(t, err, "the shipped example config must not fail verifier construction")
 	require.NotNil(t, v)
 	require.False(t, v.Enabled())
+}
+
+// uncommentSimTemplate performs, mechanically, the edit docs/simulated-relays.md
+// tells an operator to perform on the example config: find the commented
+// simulated-relay identity template and strip the leading "# " from every one
+// of its lines. It returns the rewritten document.
+//
+// The template block is located by content, not by line number: it starts at
+// the commented `identities:` key and runs for as long as the lines stay
+// comments. Locating it by content is deliberate — a test pinned to line
+// numbers stops testing the template the moment the file above it grows.
+func uncommentSimTemplate(t *testing.T, raw string) string {
+	t.Helper()
+
+	// Strips one leading '#' plus at most one space, preserving indentation.
+	// A line carrying two '#' therefore stays a comment: that is how optional
+	// fields stay inert through the operator's single uncomment pass.
+	stripOne := regexp.MustCompile(`^(\s*)# ?`)
+
+	lines := strings.Split(raw, "\n")
+	start := -1
+	for i, l := range lines {
+		if strings.TrimSpace(l) == "# identities:" {
+			start = i
+			break
+		}
+	}
+	require.NotEqual(t, -1, start,
+		"the example must carry a commented `# identities:` template; "+
+			"an active `identities:` key above a commented block cannot be uncommented as documented")
+
+	end := start
+	for end < len(lines) && strings.HasPrefix(strings.TrimSpace(lines[end]), "#") {
+		lines[end] = stripOne.ReplaceAllString(lines[end], "$1")
+		end++
+	}
+	require.Greater(t, end-start, 5, "the uncommented template looks truncated")
+
+	return strings.Join(lines, "\n")
+}
+
+// TestExampleConfig_SimulationTemplateUncommentsToInertIdentity is the
+// regression test for the documented "uncomment and fill it in" workflow.
+//
+// Two distinct ways that workflow used to betray the operator, both covered
+// here:
+//
+//  1. An active `identities: []` line sitting above the commented template
+//     made the naive uncomment produce a block sequence under a key that
+//     already held a flow-empty list — unparseable YAML, reported ~20 lines
+//     away from the line that caused it.
+//  2. `not_after` and `allowed_services` sat at the same comment depth as the
+//     required fields, so uncommenting silently pinned an expiry date and a
+//     localnet-only service restriction the operator never chose. The expiry
+//     in particular fails open-endedly and silently, on a date years away.
+//
+// The invariant: one uncomment pass over the template must yield a parseable
+// config whose single identity carries ONLY the fields the operator was asked
+// to fill in.
+func TestExampleConfig_SimulationTemplateUncommentsToInertIdentity(t *testing.T) {
+	raw, err := os.ReadFile("../config.relayer.example.yaml")
+	require.NoError(t, err)
+
+	path := writeTempConfig(t, uncommentSimTemplate(t, string(raw)))
+
+	cfg, err := LoadConfig(path)
+	require.NoError(t, err, "uncommenting the identity template must yield parseable YAML")
+
+	require.Len(t, cfg.Simulation.Identities, 1, "the template must parse as exactly one identity")
+	id := cfg.Simulation.Identities[0]
+
+	// Fields the operator is explicitly told to set.
+	require.Equal(t, "my-sim-identity", id.KeyID)
+	require.True(t, id.Enabled, "the template's per-identity switch must come through as set")
+	require.NotEmpty(t, id.AppPubKeyHex, "the template must carry an app_pubkey_hex placeholder to replace")
+	require.Len(t, id.GatewayPubKeysHex, 1, "the template must carry one gateway pubkey placeholder to replace")
+
+	// Fields the operator did NOT ask for. These are the regression.
+	require.Empty(t, id.NotAfter,
+		"uncommenting the template must not pin an expiry the operator did not choose")
+	require.Empty(t, id.AllowedServices,
+		"uncommenting the template must not restrict the identity to services the operator did not choose")
+	require.Equal(t, DefaultSimIdentityMaxRPS, id.MaxRPS,
+		"max_rps must come from the default, not from an accidentally-active template value")
+
+	// And the placeholder keys must still be unservable: turning the feature
+	// on without replacing them fails loudly, naming the field.
+	cfg.Simulation.Enabled = true
+	cfg.Simulation.ApplyDefaults()
+	err = cfg.Simulation.Validate()
+	require.Error(t, err, "placeholder pubkeys must never produce a servable identity")
+	require.True(t, errors.Is(err, ErrSimBadPubKey), "got: %v", err)
+}
+
+// TestSimulationConfig_Validate_EnabledWithNoIdentities pins the fail-fast
+// behaviour for a simulation block that is switched on but pins nothing.
+//
+// Without this, the misconfiguration is invisible at the point it is made:
+// the relayer boots, logs `identities=0`, and then rejects every simulated
+// relay with ErrSimUnknownKeyID under the metric label `verify_failed` — the
+// same label a forged signature produces. The operator sees a health-check
+// pipeline that fails uniformly, with nothing naming the empty list.
+func TestSimulationConfig_Validate_EnabledWithNoIdentities(t *testing.T) {
+	cfg := SimulationConfig{Enabled: true}
+	cfg.ApplyDefaults()
+
+	err := cfg.Validate()
+	require.Error(t, err, "enabling simulation with no identities pinned must be rejected")
+	require.True(t, errors.Is(err, ErrSimNoIdentities), "got: %v", err)
+}
+
+// A disabled block with no identities is the shipped default and must stay
+// silent — the fail-fast above must not turn the default config into an error.
+func TestSimulationConfig_Validate_DisabledWithNoIdentitiesIsOK(t *testing.T) {
+	cfg := SimulationConfig{Enabled: false}
+	cfg.ApplyDefaults()
+
+	require.NoError(t, cfg.Validate(), "the shipped default (disabled, no identities) must validate")
+}
+
+// --- SimulationConfig.ValidateAsIfEnabled() ---
+
+// ValidateAsIfEnabled is the look-ahead that keeps a disabled-but-broken block
+// from staying silent until the day someone enables it. A typo in an unused
+// identity must be reportable while the feature is still off.
+func TestSimulationConfig_ValidateAsIfEnabled_ReportsDisabledBlockDefect(t *testing.T) {
+	id := validIdentity(t)
+	id.GatewayPubKeysHex = []string{simOffCurvePubKeyHex}
+
+	cfg := SimulationConfig{Enabled: false, Identities: []SimIdentity{id}}
+	cfg.ApplyDefaults()
+
+	// Validate stays silent: a disabled block never blocks startup.
+	require.NoError(t, cfg.Validate(), "a disabled block must not block startup")
+
+	// The look-ahead names the defect anyway.
+	err := cfg.ValidateAsIfEnabled()
+	require.Error(t, err, "the look-ahead must report what enabling this config would do")
+	require.True(t, errors.Is(err, ErrSimBadPubKey), "got: %v", err)
+}
+
+// The look-ahead must agree with Validate on a config that is fine, so it
+// never produces a warning for a block that would enable cleanly.
+func TestSimulationConfig_ValidateAsIfEnabled_SilentOnValidDisabledBlock(t *testing.T) {
+	cfg := SimulationConfig{Enabled: false, Identities: []SimIdentity{validIdentity(t)}}
+	cfg.ApplyDefaults()
+
+	require.NoError(t, cfg.ValidateAsIfEnabled(), "a disabled block that would enable cleanly must not warn")
+}
+
+// An enabled config must produce byte-identical results from both entry
+// points — if they ever diverge, one of the two callers is checking something
+// the other is not.
+func TestSimulationConfig_ValidateAsIfEnabled_MatchesValidateWhenEnabled(t *testing.T) {
+	id := validIdentity(t)
+	id.NotAfter = "not-a-timestamp"
+
+	cfg := SimulationConfig{Enabled: true, Identities: []SimIdentity{id}}
+	cfg.ApplyDefaults()
+
+	validateErr := cfg.Validate()
+	lookAheadErr := cfg.ValidateAsIfEnabled()
+	require.Error(t, validateErr)
+	require.Error(t, lookAheadErr)
+	require.Equal(t, validateErr.Error(), lookAheadErr.Error(),
+		"Validate and ValidateAsIfEnabled must run the same checks when enabled")
 }
 
 // writeTempConfig writes yamlDoc to a temp file and returns its path.

--- a/relayer/simulation_config_test.go
+++ b/relayer/simulation_config_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
 
+	"github.com/pokt-network/pocket-relay-miner/logging"
 	"github.com/pokt-network/pocket-relay-miner/rings"
 )
 
@@ -187,6 +188,47 @@ func TestSimulationConfig_Validate_MalformedGatewayPubKey(t *testing.T) {
 	err := cfg.Validate()
 	require.Error(t, err)
 	require.True(t, errors.Is(err, ErrSimBadPubKey), "got: %v", err)
+}
+
+// simOffCurvePubKeyHex is 33 bytes of well-formed hex with a valid compressed
+// prefix whose x coordinate is NOT on secp256k1. Hex and length checks accept
+// it; only decoding to a curve point rejects it. This is the exact shape of
+// pubkey an operator ends up with after copying a documentation placeholder
+// into a real config.
+const simOffCurvePubKeyHex = "03bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+
+// TestSimulationConfig_Validate_OffCurveAppPubKey verifies an app_pubkey_hex
+// that is well-formed but not a curve point is rejected by config validation,
+// naming the offending identity and field, rather than surviving to fail
+// inside ring-point precompute at verifier construction.
+func TestSimulationConfig_Validate_OffCurveAppPubKey(t *testing.T) {
+	id := validIdentity(t)
+	id.AppPubKeyHex = simOffCurvePubKeyHex
+
+	cfg := SimulationConfig{Enabled: true, Identities: []SimIdentity{id}}
+	cfg.ApplyDefaults()
+
+	err := cfg.Validate()
+	require.Error(t, err)
+	require.True(t, errors.Is(err, ErrSimBadPubKey), "got: %v", err)
+	require.Contains(t, err.Error(), "app_pubkey_hex", "error must name the offending field")
+	require.Contains(t, err.Error(), id.KeyID, "error must name the offending identity")
+}
+
+// TestSimulationConfig_Validate_OffCurveGatewayPubKey is the gateway-list
+// counterpart: an off-curve ring member must be rejected at validation, with
+// the failing list index named.
+func TestSimulationConfig_Validate_OffCurveGatewayPubKey(t *testing.T) {
+	id := validIdentity(t)
+	id.GatewayPubKeysHex = []string{hexPubKey(t), simOffCurvePubKeyHex}
+
+	cfg := SimulationConfig{Enabled: true, Identities: []SimIdentity{id}}
+	cfg.ApplyDefaults()
+
+	err := cfg.Validate()
+	require.Error(t, err)
+	require.True(t, errors.Is(err, ErrSimBadPubKey), "got: %v", err)
+	require.Contains(t, err.Error(), "gateway_pubkeys_hex[1]", "error must name the offending list index")
 }
 
 func TestSimulationConfig_Validate_NegativeMaxRPS(t *testing.T) {
@@ -454,6 +496,35 @@ simulation:
 		require.Error(t, err)
 		require.True(t, errors.Is(err, ErrSimPlaceholderForbidden), "got: %v", err)
 	})
+}
+
+// TestExampleConfig_SimulationBlockStartsCleanly walks the shipped example
+// config through the exact sequence a relayer performs at startup: load,
+// validate, then build the simulation verifier. An operator who copies
+// config.relayer.example.yaml verbatim must get a relayer that starts.
+//
+// This is a regression test for a shipped example that carried illustrative
+// pubkeys which were not secp256k1 curve points: validation skipped them
+// (feature disabled), verifier construction did not, and the relayer failed to
+// boot on a feature nobody had turned on.
+func TestExampleConfig_SimulationBlockStartsCleanly(t *testing.T) {
+	const examplePath = "../config.relayer.example.yaml"
+
+	cfg, err := LoadConfig(examplePath)
+	require.NoError(t, err, "the shipped example config must load")
+
+	require.False(t, cfg.Simulation.Enabled, "the example must ship with simulation off")
+	require.Empty(t, cfg.Simulation.Identities,
+		"the example must not ship identities: illustrative pubkeys are not real curve points")
+
+	// The startup call that previously failed (cmd/cmd_relayer.go wires this
+	// with the loaded config). nil redis/signer/serviceIDs are sufficient:
+	// construction only parses config and precomputes ring points.
+	logger := logging.NewLoggerFromConfig(logging.DefaultConfig())
+	v, err := NewSimulationVerifier(logger, &cfg.Simulation, nil, nil, nil, nil)
+	require.NoError(t, err, "the shipped example config must not fail verifier construction")
+	require.NotNil(t, v)
+	require.False(t, v.Enabled())
 }
 
 // writeTempConfig writes yamlDoc to a temp file and returns its path.

--- a/relayer/simulation_config_test.go
+++ b/relayer/simulation_config_test.go
@@ -9,6 +9,7 @@ import (
 	"regexp"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
 	"github.com/stretchr/testify/require"
@@ -326,6 +327,123 @@ func TestSimulationConfig_ApplyDefaults_MultipleIdentitiesEachDefaulted(t *testi
 	require.Equal(t, 5, cfg.Identities[0].MaxRPS)
 	require.Equal(t, 20, cfg.Identities[1].MaxRPS)
 	require.Equal(t, 5, cfg.Identities[2].MaxRPS)
+}
+
+// --- SimulationConfig.ExpiredIdentities() ---
+
+// simNotAfterRef is the reference "now" for expiry tests. Fixed, never
+// time.Now(): an expiry test anchored to the wall clock silently changes
+// meaning as the dates in it recede into the past.
+var simNotAfterRef = time.Date(2026, 7, 29, 12, 0, 0, 0, time.UTC)
+
+// simIdentityWithNotAfter returns an enabled, otherwise-valid identity with
+// the given key_id and not_after.
+func simIdentityWithNotAfter(t *testing.T, keyID, notAfter string) SimIdentity {
+	t.Helper()
+	id := validIdentity(t)
+	id.KeyID = keyID
+	id.Enabled = true
+	id.NotAfter = notAfter
+	return id
+}
+
+// An identity whose not_after has already passed is dead weight: it validates,
+// it loads, and then every relay aimed at it is rejected with ErrSimExpired.
+// The operator who fat-fingered the year needs to hear about it at config
+// time, not from a silent health-check pipeline.
+func TestSimulationConfig_ExpiredIdentities_ReportsPastNotAfter(t *testing.T) {
+	cfg := SimulationConfig{Enabled: true, Identities: []SimIdentity{
+		simIdentityWithNotAfter(t, "expired", "2020-01-01T00:00:00Z"),
+	}}
+
+	require.Equal(t, []string{"expired"}, cfg.ExpiredIdentities(simNotAfterRef))
+}
+
+// The cases that must stay silent, each for its own reason.
+func TestSimulationConfig_ExpiredIdentities_SilentCases(t *testing.T) {
+	tests := []struct {
+		name     string
+		identity SimIdentity
+		why      string
+	}{
+		{
+			name:     "future not_after",
+			identity: simIdentityWithNotAfter(t, "future", "2030-01-01T00:00:00Z"),
+			why:      "an identity that expires later is the normal rotation case",
+		},
+		{
+			name:     "no not_after",
+			identity: simIdentityWithNotAfter(t, "no-expiry", ""),
+			why:      "an unset not_after means no expiry, not an expiry at the zero time",
+		},
+		{
+			name:     "unparseable not_after",
+			identity: simIdentityWithNotAfter(t, "garbage", "not-a-timestamp"),
+			why:      "a malformed not_after is Validate's rejection to make, not this advisory's",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := SimulationConfig{Enabled: true, Identities: []SimIdentity{tt.identity}}
+			require.Empty(t, cfg.ExpiredIdentities(simNotAfterRef), tt.why)
+		})
+	}
+}
+
+// A per-identity `enabled: false` already means the identity is never served,
+// so its expiry is not a finding — reporting it would train operators to
+// ignore the warning.
+func TestSimulationConfig_ExpiredIdentities_IgnoresDisabledIdentity(t *testing.T) {
+	id := simIdentityWithNotAfter(t, "expired-but-off", "2020-01-01T00:00:00Z")
+	id.Enabled = false
+
+	cfg := SimulationConfig{Enabled: true, Identities: []SimIdentity{id}}
+	require.Empty(t, cfg.ExpiredIdentities(simNotAfterRef),
+		"a disabled identity is not served, so its expiry is not a finding")
+}
+
+// The boundary must match SimulationVerifier.Verify, which rejects on
+// now.After(notAfter) — strictly after. At exactly not_after the identity is
+// still served, so it must not be reported as expired.
+func TestSimulationConfig_ExpiredIdentities_BoundaryMatchesVerify(t *testing.T) {
+	exact := simNotAfterRef.Format(time.RFC3339)
+	cfg := SimulationConfig{Enabled: true, Identities: []SimIdentity{
+		simIdentityWithNotAfter(t, "on-the-boundary", exact),
+	}}
+
+	require.Empty(t, cfg.ExpiredIdentities(simNotAfterRef),
+		"at exactly not_after the identity is still served; the advisory must not disagree with Verify")
+	require.Equal(t, []string{"on-the-boundary"},
+		cfg.ExpiredIdentities(simNotAfterRef.Add(time.Nanosecond)),
+		"one instant later it is expired, matching Verify's now.After(notAfter)")
+}
+
+// Multiple expired identities are all reported, in config order, so the
+// operator sees every one in a single pass instead of fixing them one restart
+// at a time.
+func TestSimulationConfig_ExpiredIdentities_AllInConfigOrder(t *testing.T) {
+	cfg := SimulationConfig{Enabled: true, Identities: []SimIdentity{
+		simIdentityWithNotAfter(t, "dead-1", "2020-01-01T00:00:00Z"),
+		simIdentityWithNotAfter(t, "alive", "2030-01-01T00:00:00Z"),
+		simIdentityWithNotAfter(t, "dead-2", "2021-06-01T00:00:00Z"),
+	}}
+
+	require.Equal(t, []string{"dead-1", "dead-2"}, cfg.ExpiredIdentities(simNotAfterRef))
+}
+
+// Expiry is advisory and must never become a startup failure: a not_after that
+// passes while the relayer is running would otherwise turn the next restart
+// into an outage of real, paid traffic over a dead simulation identity.
+func TestSimulationConfig_Validate_ExpiredIdentityStillValidates(t *testing.T) {
+	cfg := SimulationConfig{Enabled: true, Identities: []SimIdentity{
+		simIdentityWithNotAfter(t, "expired", "2020-01-01T00:00:00Z"),
+	}}
+	cfg.ApplyDefaults()
+
+	require.NoError(t, cfg.Validate(),
+		"an expired identity must not block startup: real traffic must not go down over a dead sim identity")
+	require.NoError(t, cfg.ValidateAsIfEnabled(), "the look-ahead must agree with Validate here")
 }
 
 // --- YAML round-trip ---

--- a/relayer/simulation_test.go
+++ b/relayer/simulation_test.go
@@ -328,3 +328,87 @@ func TestSimDirectiveExtractors(t *testing.T) {
 	md := metadata.New(map[string]string{MetaSimulationKeyID: "kg"})
 	require.Equal(t, "kg", SimDirectiveFromGRPC(md).KeyID)
 }
+
+// --- construction and reload with the feature disabled ---------------------
+
+// unusableSimConfig returns a simulation config whose identity can never be
+// turned into ring points: the gateway pubkey is well-formed hex of the right
+// length whose x coordinate is not on secp256k1. This is the shape of config
+// an operator ends up with after copying an example simulation block verbatim
+// without substituting their own keys.
+func unusableSimConfig(enabled bool) *SimulationConfig {
+	cfg := &SimulationConfig{
+		Enabled: enabled,
+		Identities: []SimIdentity{{
+			KeyID:             "example-identity",
+			Enabled:           true,
+			AppPubKeyHex:      hex.EncodeToString(secp256k1.GenPrivKey().PubKey().Bytes()),
+			GatewayPubKeysHex: []string{simOffCurvePubKeyHex},
+		}},
+	}
+	cfg.ApplyDefaults()
+	return cfg
+}
+
+// TestNewSimulationVerifier_Disabled_SkipsIdentityBuild pins the contract that
+// SimulationConfig.Validate documents: with the feature off, the identity list
+// is never inspected, so an unusable identity cannot block relayer startup.
+// Validate is a no-op when disabled, so construction is the only place this
+// config could fail — it must not.
+func TestNewSimulationVerifier_Disabled_SkipsIdentityBuild(t *testing.T) {
+	logger := logging.NewLoggerFromConfig(logging.DefaultConfig())
+	cfg := unusableSimConfig(false)
+
+	// Validate agreeing is a precondition: it is what lets this config reach
+	// construction untouched in the first place.
+	require.NoError(t, cfg.Validate(), "disabled config must pass validation")
+
+	v, err := NewSimulationVerifier(logger, cfg, nil, nil, nil, nil)
+	require.NoError(t, err, "a disabled simulation block must not fail startup")
+	require.NotNil(t, v)
+	require.False(t, v.Enabled())
+
+	// No identity was built, so nothing is servable even if a caller reaches
+	// Verify without checking Enabled() first.
+	require.Empty(t, *v.identities.Load())
+	require.ErrorIs(t, v.Verify(context.Background(), "example-identity", nil), ErrSimUnknownKeyID)
+}
+
+// TestNewSimulationVerifier_Enabled_UnusableIdentityErrors is the other half of
+// the contract: turning the feature on must surface the unusable identity
+// rather than starting with a silently empty identity set.
+func TestNewSimulationVerifier_Enabled_UnusableIdentityErrors(t *testing.T) {
+	logger := logging.NewLoggerFromConfig(logging.DefaultConfig())
+
+	v, err := NewSimulationVerifier(logger, unusableSimConfig(true), nil, nil, nil, nil)
+	require.Error(t, err)
+	require.Nil(t, v)
+	require.Contains(t, err.Error(), "example-identity", "error must name the offending identity")
+}
+
+// TestSimReload_ToDisabledWithUnusableIdentity verifies the same skip applies
+// on the reload path: switching the feature off with an unusable identity in
+// the new config must succeed and stop serving, not fail the reload.
+func TestSimReload_ToDisabledWithUnusableIdentity(t *testing.T) {
+	f := newSimFixture(t)
+	require.True(t, f.verifier.Enabled())
+	require.NoError(t, f.verifier.Verify(context.Background(), simTestKeyID, f.validRelay(t)))
+
+	require.NoError(t, f.verifier.Reload(unusableSimConfig(false)))
+	require.False(t, f.verifier.Enabled())
+	require.Empty(t, *f.verifier.identities.Load())
+}
+
+// TestSimReload_EnabledUnusableIdentityKeepsPreviousIdentities verifies a
+// failed reload is atomic: a bad new config must leave the previously serving
+// identity map in place rather than half-applying an empty or partial set.
+func TestSimReload_EnabledUnusableIdentityKeepsPreviousIdentities(t *testing.T) {
+	f := newSimFixture(t)
+
+	err := f.verifier.Reload(unusableSimConfig(true))
+	require.Error(t, err)
+
+	require.True(t, f.verifier.Enabled(), "failed reload must not flip the enabled flag")
+	require.NoError(t, f.verifier.Verify(context.Background(), simTestKeyID, f.validRelay(t)),
+		"previously loaded identity must still serve after a failed reload")
+}

--- a/rings/pinned.go
+++ b/rings/pinned.go
@@ -14,6 +14,13 @@ import (
 // PubKeyFromHex parses a compressed secp256k1 public key from its hex
 // encoding (33 bytes / 66 hex characters). This is how a pinned ring member
 // public key from config (rather than an on-chain account query) is loaded.
+//
+// The key is decoded all the way to a curve point, not just length-checked:
+// a well-formed 33-byte blob with a valid 0x02/0x03 prefix can still carry an
+// x coordinate that is not on secp256k1. Without this check such a key passes
+// config validation and only fails later at ring-point precompute, surfacing
+// a low-level crypto error at startup instead of a config error at the field
+// that caused it.
 func PubKeyFromHex(hexStr string) (cryptotypes.PubKey, error) {
 	keyBz, err := hex.DecodeString(hexStr)
 	if err != nil {
@@ -27,7 +34,12 @@ func PubKeyFromHex(hexStr string) (cryptotypes.PubKey, error) {
 		)
 	}
 
-	return &secp256k1.PubKey{Key: keyBz}, nil
+	pubKey := &secp256k1.PubKey{Key: keyBz}
+	if _, err := pointsFromPublicKeys(pubKey); err != nil {
+		return nil, fmt.Errorf("pubkey is not a valid secp256k1 curve point: %w", err)
+	}
+
+	return pubKey, nil
 }
 
 // PrecomputeRingPoints converts the given public keys to secp256k1 curve

--- a/rings/pinned_test.go
+++ b/rings/pinned_test.go
@@ -301,3 +301,41 @@ func TestPrecomputeRingPoints_EmptyKeys(t *testing.T) {
 	require.NoError(t, err)
 	require.Empty(t, pts)
 }
+
+// offCurvePubKeyHex is 33 bytes of well-formed hex with a valid compressed
+// prefix whose x coordinate is NOT a point on secp256k1. Length and prefix
+// checks alone accept it; only decoding to a curve point rejects it.
+const offCurvePubKeyHex = "03bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+
+// TestPubKeyFromHex_OffCurve verifies a correctly-sized, correctly-prefixed
+// pubkey whose x coordinate is not on secp256k1 is rejected at parse time.
+// Without this, such a key passes every config-level check and only fails
+// later inside PrecomputeRingPoints, turning an operator config mistake into
+// an opaque crypto error raised far from the field that caused it.
+func TestPubKeyFromHex_OffCurve(t *testing.T) {
+	// Guard the fixture itself: if this ever became a valid point the test
+	// would silently stop covering the off-curve path.
+	rawKey, decodeErr := hex.DecodeString(offCurvePubKeyHex)
+	require.NoError(t, decodeErr)
+	require.Len(t, rawKey, secp256k1.PubKeySize)
+	_, curveErr := ring_secp256k1.NewCurve().DecodeToPoint(rawKey)
+	require.Error(t, curveErr, "fixture must be off-curve for this test to mean anything")
+
+	parsed, err := PubKeyFromHex(offCurvePubKeyHex)
+	require.Error(t, err)
+	require.Nil(t, parsed)
+	require.Contains(t, err.Error(), "not a valid secp256k1 curve point")
+}
+
+// TestPubKeyFromHex_OnCurveNonCanonicalLooking guards against over-correction:
+// an x coordinate that looks like filler but IS on the curve must still parse.
+// The compressed key 0x02 || 0xaa*32 is one such point, so a curve check must
+// not be implemented as a "looks like a placeholder" heuristic.
+func TestPubKeyFromHex_OnCurveNonCanonicalLooking(t *testing.T) {
+	const onCurveHex = "02aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+	parsed, err := PubKeyFromHex(onCurveHex)
+	require.NoError(t, err)
+	require.NotNil(t, parsed)
+	require.Equal(t, onCurveHex, hex.EncodeToString(parsed.Bytes()))
+}

--- a/tilt/k8s/miner.Tiltfile
+++ b/tilt/k8s/miner.Tiltfile
@@ -1,7 +1,7 @@
 # miner.tilt - Miner deployment (HA mode with leader election)
 
 load("./ports.Tiltfile", "get_miner_ports")
-load("./utils.Tiltfile", "deep_merge", "read_miner_example_config", "get_redis_host", "apply_k8s_overrides_miner")
+load("./utils.Tiltfile", "deep_merge", "read_miner_example_config", "get_redis_host", "apply_k8s_overrides_miner", "config_hash")
 
 def deploy_miners(config):
     """Deploy miner as a Deployment with N replicas"""
@@ -11,14 +11,15 @@ def deploy_miners(config):
 
     print("Deploying miner Deployment with {} replica(s)...".format(config["miner"]["count"]))
 
-    # Create miner ConfigMap first
-    create_miner_configmap(config)
+    # Create miner ConfigMap first, and reuse its rendered YAML so the
+    # Deployment can carry the config hash that rolls the pods on a change.
+    miner_config_yaml = create_miner_configmap(config)
 
     # Deploy single miner Deployment with replicas
-    deploy_miner_deployment(config)
+    deploy_miner_deployment(config, config_hash(miner_config_yaml))
 
 def create_miner_configmap(config):
-    """Create ConfigMap with miner configuration"""
+    """Create ConfigMap with miner configuration. Returns the rendered YAML."""
     miner_config_dict = generate_miner_config(config)
 
     # Add known_applications from parent config if available
@@ -40,7 +41,9 @@ data:
 
     k8s_yaml(blob(miner_configmap))
 
-def deploy_miner_deployment(config):
+    return miner_config_yaml
+
+def deploy_miner_deployment(config, miner_config_hash):
     """Deploy miner as a single Deployment with N replicas"""
 
     # Miner Deployment with replicas + Service
@@ -60,6 +63,10 @@ spec:
     metadata:
       labels:
         app: miner
+      annotations:
+        # See config_hash in utils.Tiltfile: a mounted ConfigMap change does not
+        # roll pods by itself, and the miner reads its config only at startup.
+        pocket-relay-miner/config-hash: "{}"
     spec:
       containers:
       - name: miner
@@ -128,6 +135,7 @@ spec:
     name: pprof
 """.format(
         config["miner"]["count"],
+        miner_config_hash,
         config["global"]["image"],
         "debug" if config["global"]["debug"] else "info"
     )

--- a/tilt/k8s/relayer.Tiltfile
+++ b/tilt/k8s/relayer.Tiltfile
@@ -1,7 +1,7 @@
 # relayer.tilt - Relayer deployment (stateless, waits for miners)
 
 load("./ports.Tiltfile", "get_relayer_ports")
-load("./utils.Tiltfile", "deep_merge", "read_relayer_example_config", "get_redis_host", "apply_k8s_overrides_relayer")
+load("./utils.Tiltfile", "deep_merge", "read_relayer_example_config", "get_redis_host", "apply_k8s_overrides_relayer", "config_hash")
 
 def deploy_relayers(config):
     """Deploy relayer as a Deployment with N replicas"""
@@ -11,16 +11,18 @@ def deploy_relayers(config):
 
     print("Deploying relayer Deployment with {} replica(s)...".format(config["relayer"]["count"]))
 
+    # Render the config once: the ConfigMap carries it, and the Deployment
+    # carries its hash so a config edit actually rolls the pods.
+    relayer_config_yaml = str(encode_yaml(generate_relayer_config(config)))
+
     # Create relayer ConfigMap first
-    create_relayer_configmap(config)
+    create_relayer_configmap(relayer_config_yaml)
 
     # Deploy single relayer Deployment with replicas
-    deploy_relayer_deployment(config)
+    deploy_relayer_deployment(config, config_hash(relayer_config_yaml))
 
-def create_relayer_configmap(config):
+def create_relayer_configmap(relayer_config_yaml):
     """Create ConfigMap with relayer configuration"""
-    relayer_config_dict = generate_relayer_config(config)
-    relayer_config_yaml = str(encode_yaml(relayer_config_dict))
     relayer_config_indented = relayer_config_yaml.replace("\n", "\n    ")
 
     relayer_configmap = """
@@ -35,7 +37,7 @@ data:
 
     k8s_yaml(blob(relayer_configmap))
 
-def deploy_relayer_deployment(config):
+def deploy_relayer_deployment(config, relayer_config_hash):
     """Deploy relayer as a single Deployment with N replicas"""
 
     # Relayer Deployment with replicas + Service
@@ -55,6 +57,12 @@ spec:
     metadata:
       labels:
         app: relayer
+      annotations:
+        # Hash of the rendered config. A mounted ConfigMap change does not roll
+        # pods on its own, and the relayer reads its config only at startup, so
+        # without this a config edit would update the ConfigMap and leave the
+        # running relayers on the old one.
+        pocket-relay-miner/config-hash: "{}"
     spec:
       containers:
       - name: relayer
@@ -139,6 +147,7 @@ spec:
     name: pprof
 """.format(
         config["relayer"]["count"],
+        relayer_config_hash,
         config["global"]["image"],
         "debug" if config["global"]["debug"] else "info"
     )

--- a/tilt/k8s/utils.Tiltfile
+++ b/tilt/k8s/utils.Tiltfile
@@ -124,6 +124,23 @@ def apply_k8s_overrides_relayer(config, redis_host):
     # keypairs pinned (one identity per service, since each service uses its own
     # app key). These are PUBLIC localnet dev keys — NEVER enable simulation with
     # them on a real deployment.
+    #
+    # Injected ONLY when the config does not mention identities at all. This
+    # function runs on the deploy path, AFTER tilt_config.yaml has been merged in,
+    # so an unconditional assignment here silently discarded whatever the operator
+    # wrote: editing simulation identities in tilt_config.yaml had no effect, and
+    # the file documented a knob it did not control.
+    #
+    # The test is key PRESENCE, not truthiness, so the two intents stay
+    # distinguishable: an absent `identities` means "I did not configure this,
+    # give me the localnet defaults" (what config.relayer.example.yaml ships),
+    # while an explicit `identities: []` means "I want none" and must reach the
+    # relayer as-is — enabling simulation with nothing pinned is a config error
+    # the relayer is supposed to reject, and injecting defaults would hide it.
+    _sim = config.get("simulation") or {}
+    if "identities" in _sim:
+        return config
+
     _gw1 = "025821a2ac597a034250ac14b772efccf9297aa7c4bea5444564059a7cfb152063"
     config["simulation"] = {
         "enabled": True,
@@ -149,6 +166,25 @@ def apply_k8s_overrides_relayer(config, redis_host):
     }
 
     return config
+
+def config_hash(config_yaml):
+    """Return a short sha256 of a rendered config, for a pod-template annotation.
+
+    Kubernetes does NOT restart pods when a mounted ConfigMap changes: the
+    Deployment's pod template is untouched, so there is nothing to roll. Both the
+    relayer and the miner read their config once at startup — simulation
+    identities in particular are not hot-reloaded — so editing the config used to
+    update the ConfigMap and change nothing that was running, with no error and
+    no signal. Stamping this hash into the pod template turns a config change
+    into a template change, which is what makes Kubernetes roll the pods.
+
+    Truncated to 16 hex chars: this is a change detector, not a security control.
+    """
+    return str(local(
+        "cat << 'PRM_CFG_EOF' | sha256sum | cut -c1-16\n{}\nPRM_CFG_EOF".format(config_yaml),
+        quiet=True,
+        echo_off=True,
+    )).strip()
 
 def dict_get(d, key, default=None):
     """Safe dictionary get with default value"""


### PR DESCRIPTION
## Reported problem

A relayer configured by copying `config.relayer.example.yaml` failed to start — on a feature that was switched off:

```
failed to create simulation verifier: simulation identity "example-sim-identity":
precompute ring points: invalid public key: x coordinate bbbb...bbbb is not on
the secp256k1 curve
```

Nothing was served and there was no security exposure: `simulation.enabled` was `false` throughout. The relayer simply refused to boot.

## Root cause

Two defects combined.

**1. Pubkey validation was shallow.** `rings.PubKeyFromHex` hex-decoded and length-checked its input but never decoded to a curve point. A 33-byte value with a valid `0x02`/`0x03` compressed prefix whose x coordinate is not on secp256k1 therefore passed `SimulationConfig.Validate` and only blew up later inside `PrecomputeRingPoints`, surfacing an opaque crypto error far from the field that caused it.

**2. A disabled block was still built.** `buildSimIdentities` parsed and precomputed ring points for every identity regardless of `simulation.enabled`. That contradicts `SimulationConfig.Validate`'s documented contract:

> Validate checks the simulation config for correctness. It is a no-op when Enabled is false, so a disabled (default) simulation block never blocks startup regardless of what garbage it contains.

`docs/simulated-relays.md` told operators the same thing. The code disagreed with both.

**3. The example config was the trigger.** It shipped full-length illustrative pubkeys. `03bbbb…bb` is not a curve point (`02aaaa…aa` happens to be one, which is why the error names only the gateway key). Copying the file verbatim was enough to reproduce the failure.

## Changes

- `rings/pinned.go` — `PubKeyFromHex` decodes to a curve point. Off-curve keys are now rejected by config validation, naming the identity and field:
  ```
  simulation.identities[0] (key_id=my-sim-identity): gateway_pubkeys_hex[0]: simulation identity: malformed pubkey hex: pubkey is not a valid secp256k1 curve point: invalid public key: x coordinate bbbb...bbbb is not on the secp256k1 curve
  ```
  All callers are config-load paths, not per-relay hot paths — no throughput impact.
- `relayer/simulation.go` — `buildSimIdentities` returns an empty map when the feature is off, honoring the documented contract. A caller reaching `Verify` without checking `Enabled()` now gets `ErrSimUnknownKeyID` instead of a servable identity.
- `config.relayer.example.yaml` — `identities: []`, with the field shape in comments and no paste-ready values.
- `docs/simulated-relays.md` — states that a disabled block is neither validated nor loaded, documents the curve-point requirement and the exact rejection message, and points at the empty example block.

## Tests

- `rings`: off-curve rejection, plus a guard that an on-curve but filler-looking key (`02aaaa…aa`) still parses — the check must be curve arithmetic, not a "looks like a placeholder" heuristic.
- `relayer`: off-curve app and gateway pubkeys rejected by `Validate` with field and index named; construction and reload with the feature off; failed reload leaves the previously serving identity map intact.
- `relayer`: `TestExampleConfig_SimulationBlockStartsCleanly` loads the shipped example config and runs the exact startup sequence that broke — regression cover for the example file itself.

## Verification

- `go build ./...` — clean
- `go test -tags test ./...` — all pass
- `go test -tags test -race ./rings/ ./relayer/ ./cmd/` — clean
- `go vet ./...` — clean
- `make lint` — 0 issues; the remaining `tilt/backend-server/pb` typecheck error is pre-existing (missing generated proto) and untouched here
- `gofmt -l .` — empty

## Operator note

Anyone hitting this today can unblock by removing the `simulation:` block from their config, or setting `identities: []`. The feature is off by default and the block is not required.